### PR TITLE
Add support for Int and Bool conversion from String

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,17 +4,5 @@ let package = Package(
   name: "Redbird",
   dependencies: [
     .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 4)
-  ],
-  exclude: [],
-  targets: [
-    Target(
-      name: "Redbird"
-    ),
-    Target(
-      name: "RedbirdExample",
-      dependencies: [
-        .Target(name: "Redbird")
-      ]
-    )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,20 @@
 import PackageDescription
 
 let package = Package(
-  name: "Redbird",
-  dependencies: [
-    .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 4)
-  ]
+    name: "Redbird",
+    dependencies: [
+        .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 4)
+    ],
+    exclude: [],
+    targets: [
+        Target(
+            name: "Redbird"
+        ),
+        Target(
+            name: "RedbirdExample",
+            dependencies: [
+                .Target(name: "Redbird")
+            ]
+        )
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "Redbird",
     dependencies: [
-        .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 4)
+        .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 8)
     ],
     exclude: [],
     targets: [

--- a/Sources/Redbird/ClientSocket.swift
+++ b/Sources/Redbird/ClientSocket.swift
@@ -29,7 +29,7 @@ class ClientSocket: Socket {
     let client: TCPClient
     
     init(address: String, port: UInt16) throws {
-        let addr = InternetAddress(hostname: address, port: .portNumber(port))
+        let addr = InternetAddress(hostname: address, port: port)
         self.client = try TCPClient(address: addr)
     }
 

--- a/Sources/Redbird/ExternalTypeConversions.swift
+++ b/Sources/Redbird/ExternalTypeConversions.swift
@@ -10,54 +10,92 @@ extension RespObject {
     
     public func toArray() throws -> [RespObject] {
         switch self.respType {
-        case .Array: return (self as! RespArray).content
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Array")
+        case .Array:
+            return (self as! RespArray).content
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Array")
         }
     }
     
     public func toMaybeArray() throws -> [RespObject]? {
         switch self.respType {
-        case .Array: return (self as! RespArray).content
-        case .NullArray: return nil
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "MaybeArray")
+        case .Array:
+            return (self as! RespArray).content
+        case .NullArray:
+            return nil
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "MaybeArray")
         }
     }
     
     public func toString() throws -> String {
         switch self.respType {
-        case .SimpleString: return (self as! RespSimpleString).content
-        case .BulkString: return (self as! RespBulkString).content
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "String")
+        case .SimpleString:
+            return (self as! RespSimpleString).content
+        case .BulkString:
+            return (self as! RespBulkString).content
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "String")
         }
     }
 
     public func toMaybeString() throws -> String? {
         switch self.respType {
-        case .SimpleString: return (self as! RespSimpleString).content
-        case .BulkString: return (self as! RespBulkString).content
-        case .NullBulkString: return nil
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "MaybeString")
+        case .SimpleString:
+            return (self as! RespSimpleString).content
+        case .BulkString:
+            return (self as! RespBulkString).content
+        case .NullBulkString:
+            return nil
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "MaybeString")
         }
     }
     
     public func toInt() throws -> Int {
         switch self.respType {
-        case .Integer: return Int((self as! RespInteger).intContent)
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Int")
+        case .Integer:
+            return Int((self as! RespInteger).intContent)
+        case .SimpleString:
+            if let intValue = Int((self as! RespSimpleString).content) {
+                return intValue
+            }
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Int")
+        case .BulkString:
+            if let intValue = Int((self as! RespBulkString).content) {
+                return intValue
+            }
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Int")
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Int")
         }
     }
     
     public func toBool() throws -> Bool {
         switch self.respType {
-        case .Integer: return (self as! RespInteger).boolContent
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Bool")
+        case .Integer:
+            return (self as! RespInteger).boolContent
+        case .SimpleString:
+            if let intValue = Int((self as! RespSimpleString).content) {
+                return intValue != 0
+            }
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Bool")
+        case .BulkString:
+            if let intValue = Int((self as! RespBulkString).content) {
+                return intValue != 0
+            }
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Bool")
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Bool")
         }
     }
     
     public func toError() throws -> RespError {
         switch self.respType {
-        case .Error: return (self as! RespError)
-        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Error")
+        case .Error:
+            return (self as! RespError)
+        default:
+            throw RedbirdError.WrongNativeTypeUnboxing(self, "Error")
         }
     }
 

--- a/Sources/Redbird/Redbird.swift
+++ b/Sources/Redbird/Redbird.swift
@@ -77,8 +77,9 @@ public class Redbird {
             }
             if let e = error as? SocketError {
                 switch e.type {
-                case .SendFailedToSendAllBytes: fallthrough
-                case .ReadFailed:
+                case .sendFailedToSendAllBytes:
+                    fallthrough
+                case .readFailed:
                     retry = true
                 default: break
                 }

--- a/Tests/Redbird/ConversionTests.swift
+++ b/Tests/Redbird/ConversionTests.swift
@@ -87,6 +87,14 @@ class ConversionTests: XCTestCase {
             let orig = try RespInteger(content: "12")
             let ret = try orig.toInt()
             XCTAssertEqual(ret, 12)
+            
+            let origSimpStr = try RespSimpleString(content: "13")
+            let retSimpStr = try origSimpStr.toInt()
+            XCTAssertEqual(retSimpStr, 13)
+            
+            let origBulkStr = try RespBulkString(content: "14")
+            let retBulkStr = try origBulkStr.toInt()
+            XCTAssertEqual(retBulkStr, 14)
         }
     }
 


### PR DESCRIPTION
`toInt()` and `toBool()` methods attempt to convert from `simple string` and `bulk string` when necessary.

See #32 
