### PR TITLE
Add @discardableResult attr to pipeline enqueue

### DIFF
--- a/Sources/Redbird/Redbird.swift
+++ b/Sources/Redbird/Redbird.swift
@@ -137,7 +137,8 @@ public class Pipeline: Redbird {
     public override func command(_ name: String, params: [String]) throws -> RespObject {
         fatalError("You must call enqueue on a Pipeline instance")
     }
-    
+
+    @discardableResult
     public func enqueue(_ name: String, params: [String] = []) throws -> Pipeline {
         let formatted = try self.formatCommand(name: name, params: params)
         self.commands.append(formatted)


### PR DESCRIPTION
This removes warning when pipeline used in such workflow:

```swift
let pipeline = connection.pipeline()

try pipeline.enqueue("PING")
if true { try pipeline.enqueue("PING") }

print(try pipeline.execute())
```