### PR TITLE
Fix error in code that required REDIS to include a count of parameter…

### DIFF
--- a/Sources/Redbird/Array.swift
+++ b/Sources/Redbird/Array.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespArray: RespObject {
-    static var signature: String = "*"
+    static let signature: String = "*"
     public let respType: RespType = .Array
     
     public let content: [RespObject]

--- a/Sources/Redbird/BulkString.swift
+++ b/Sources/Redbird/BulkString.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespBulkString: RespObject {
-    static var signature: String = "$"
+    static let signature: String = "$"
     public let respType: RespType = .BulkString
     
     public let content: String

--- a/Sources/Redbird/Error.swift
+++ b/Sources/Redbird/Error.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespError: RespObject, Error {
-    static var signature: String = "-"
+    static let signature: String = "-"
     public let respType: RespType = .Error
     
     public let content: String

--- a/Sources/Redbird/Integer.swift
+++ b/Sources/Redbird/Integer.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespInteger: RespObject {
-    static var signature: String = ":"
+    static let signature: String = ":"
     public let respType: RespType = .Integer
     
     public let intContent: Int64

--- a/Sources/Redbird/Null.swift
+++ b/Sources/Redbird/Null.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespNullBulkString: RespObject {
-    static var signature: String = "$-1\r\n"
+    static let signature: String = "$-1\r\n"
     public var respType: RespType = .NullBulkString
 }
 

--- a/Sources/Redbird/Parsers.swift
+++ b/Sources/Redbird/Parsers.swift
@@ -48,13 +48,13 @@ struct InitialParser: Parser {
         
         let parser: Parser
         switch signature {
-        case RespError.signature: parser = ErrorParser()
-        case RespSimpleString.signature: parser = SimpleStringParser()
-        case RespInteger.signature: parser = IntegerParser()
-        case RespBulkString.signature: parser = BulkStringParser()
-        case RespArray.signature: parser = ArrayParser()
-        default:
-            throw RedbirdError.parsingStringNotThisType(try alreadyRead.stringView(), nil)
+            case RespError.signature: parser = ErrorParser()
+            case RespSimpleString.signature: parser = SimpleStringParser()
+            case RespInteger.signature: parser = IntegerParser()
+            case RespBulkString.signature: parser = BulkStringParser()
+            case RespArray.signature: parser = ArrayParser()
+            default:
+                throw RedbirdError.parsingStringNotThisType(try alreadyRead.stringView(), nil)
         }
         
         return try parser.parse(read, reader: reader)
@@ -177,9 +177,7 @@ struct ArrayParser: Parser {
         }
         let rawCountString = try head.stringView()
         let countString = rawCountString.strippedInitialSignatureAndTrailingTerminator()
-        guard let count = Int(countString) else {
-            throw RedbirdError.arrayProvidedUnparseableCount(countString)
-        }
+        let count = Int(countString) ?? 3 // Default to 3 if not specified
         
         //if byte count is -1, then return a null array
         if count == -1 {

--- a/Sources/Redbird/Redbird.swift
+++ b/Sources/Redbird/Redbird.swift
@@ -184,3 +184,17 @@ struct CommandFormatter {
     }
 }
 
+// Add support for pub-sub
+extension Redbird {
+    public func read() throws -> RespObject
+    {
+        var ret: RespObject?
+        try self.handleComms {
+            let reader: SocketReader = self.socket
+            let (responseObject, _) = try InitialParser().parse([], reader: reader)
+            ret = responseObject
+        }
+        guard let retValue = ret else { throw RedbirdError.noDataFromSocket }
+        return retValue
+    }
+}

--- a/Sources/Redbird/SimpleString.swift
+++ b/Sources/Redbird/SimpleString.swift
@@ -7,7 +7,7 @@
 //
 
 public struct RespSimpleString: RespObject {
-    static var signature: String = "+"
+    static let signature: String = "+"
     public let respType: RespType = .SimpleString
     
     public let content: String


### PR DESCRIPTION
…s for Arrays when the default of */r/n means a count of 3.  This fixes the pub sub functionality.

Cleaned up some constants that were declared as var.
Added in a read() function as suggested by surendratiwari3 but corrected the code to avoid unprotected unwrapping of optionals.