### PR TITLE
Omit keyword of arguments

### DIFF
--- a/Sources/Redis/Pipeline.swift
+++ b/Sources/Redis/Pipeline.swift
@@ -9,7 +9,7 @@ public class Pipeline<StreamType: DuplexStream> {
     }
 
     @discardableResult
-    public func enqueue(_ command: Command, params: [Bytes] = []) throws -> Pipeline {
+    public func enqueue(_ command: Command, _ params: [Bytes] = []) throws -> Pipeline {
         let query = client.format(command, params)
         try client.serializer.serialize(query)
         queuedCommands += 1


### PR DESCRIPTION
Hi, I tried to use v2.0.0-alpha.1.
I found a little difference from README.
I think `Pipeline#enqueue(_, _)` is valid to unify new interfaces each other.

In README.md
```swift
let client = try TCPClient()
let results = try client
    .makePipeline()
    .enqueue(.set, ["FOO", "BAR"])
    .enqueue(.set, ["Hello", "World"])
    .enqueue(.get, ["Hello"])
    .enqueue(.get, ["FOO"])
    .execute()
```