### PR TITLE
Commands for working with hashes and the keys command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@
         <img src="http://img.shields.io/badge/swift-3.1-brightgreen.svg" alt="Swift 3.1">
     </a>
 </center>
+ 

--- a/Sources/Redis/Command.swift
+++ b/Sources/Redis/Command.swift
@@ -2,6 +2,11 @@
 public enum Command {
     case get
     case set
+    case hget
+    case hset
+    case hdel
+    case hkeys
+    case keys
     case authorize
     case delete
     case client
@@ -24,6 +29,16 @@ extension Command {
             return [.G, .E, .T]
         case .set:
             return [.S, .E, .T]
+        case .hget:
+            return [.H, .G, .E, .T]
+        case .hset:
+            return [.H, .S, .E, .T]
+        case .hkeys:
+            return [.H, .K, .E, .Y, .S]
+        case .hdel:
+            return [.H, .D, .E, .L]
+        case .keys:
+            return [.K, .E, .Y, .S]
         case .authorize:
             return [.A, .U, .T, .H]
         case .delete:

--- a/Tests/RedisTests/LiveTests.swift
+++ b/Tests/RedisTests/LiveTests.swift
@@ -10,6 +10,17 @@ class LiveTests: XCTestCase {
         XCTAssertEqual(res?.string, "PONG")
     }
 
+    func testKeys() throws {
+        let client = try TCPClient()
+        try client.command(.flushall)
+        try client.command(.set, ["FOO", "BAR"])
+        try client.command(.set, ["BAR", "BAZ"])
+
+        let res = try client.command(.keys, ["*"])
+
+        XCTAssertEqual(res!.array!.flatMap { $0?.string }, ["FOO", "BAR"])
+    }
+
     func testString() throws {
         let client = try TCPClient()
         do {
@@ -32,6 +43,36 @@ class LiveTests: XCTestCase {
         do {
             let res = try client.command(.get, ["FOO"])
             XCTAssert(res!.bytes! == random)
+        }
+    }
+
+    func testHash() throws {
+        let client = try TCPClient()
+        try client.command(.flushall)
+        do {
+            let res = try client.command(.hset, ["BAZ", "BAR", "FOO"])
+            XCTAssertEqual(res?.int, 1)
+        }
+        do {
+            let res = try client.command(.hget, ["BAZ", "BAR"])
+            XCTAssertEqual(res?.string, "FOO")
+        }
+        do {
+            let res = try client.command(.hset, ["BAZ", "BAR", "BAR"])
+            XCTAssertEqual(res?.int, 0)
+        }
+        do {
+            let res = try client.command(.hget, ["BAZ", "BAR"])
+            XCTAssertEqual(res?.string, "BAR")
+        }
+        do {
+            let res = try client.command(.hkeys, ["BAZ"])
+            XCTAssertEqual(res!.array!.flatMap { $0?.string }, ["BAR"])
+        }
+        do {
+            try client.command(.hdel, ["BAZ", "BAR"])
+            let res = try client.command(.hkeys, ["BAZ"])
+            XCTAssertEqual(res!.array!.flatMap { $0?.string }, [])
         }
     }
 


### PR DESCRIPTION
This adds the following commands:

[HGET](https://redis.io/commands/hget)

[HSET](https://redis.io/commands/hset)

[HDEL](https://redis.io/commands/hdel)
- [ ] Test returned value

[HKEYS](https://redis.io/commands/hdel)

[Keys](https://redis.io/commands/keys)