### PR TITLE
Add swift4 support

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Redis",
+    products: [
+        .library(name: "Redis", targets: ["Redis"]),
+    ],
+    dependencies: [
+        // Core extensions, type-aliases, and functions that facilitate common tasks.
+        .package(url: "https://github.com/vapor/core.git", from: "2.1.0"),
+
+        // A formatted data encapsulation meant to facilitate the transformation from one object to another.
+        .package(url: "https://github.com/vapor/node.git", from: "2.1.0"),
+
+        // Pure-Swift Sockets: TCP, UDP; Client, Server; Linux, OS X.
+        .package(url: "https://github.com/vapor/sockets.git", from: "2.1.0"),
+
+        // Module for generating random bytes and numbers (for tests).
+        .package(url: "https://github.com/vapor/random.git", from: "1.2.0")
+    ],
+    targets: [
+        .target(name: "Redis", dependencies: ["Core", "Node", "Sockets", "Random"]),
+        .testTarget(name: "RedisTests", dependencies: ["Redis"])
+    ]
+)

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
     - swift build -c release
     - swift test
     - sudo apt-get remove swift
-    - sudo apt-get install swift-beta
+    - sudo apt-get install swift=3.1.1
     - swift build
     - swift build -c release
     - swift test

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,15 @@ machine:
 dependencies:
   override:
     - eval "$(curl -sL https://apt.vapor.sh)"
-    - sudo apt-get install vapor cmysql
+    - sudo apt-get install swift vapor cmysql
     - sudo chmod -R a+rx /usr/
 test:
   override:
     - swift build
     - swift build -c release
     - swift test
-    
+    - sudo apt-get remove swift
+    - sudo apt-get install swift-beta
+    - swift build
+    - swift build -c release
+    - swift test


### PR DESCRIPTION
```
jmsmith@SF-M-JSMITH01 ~/w/B/redis (master)> swift build                                                                                                                 13:56:16
Fetching https://github.com/vapor/core.git
Fetching https://github.com/vapor/node.git
Fetching https://github.com/vapor/sockets.git
Fetching https://github.com/vapor/random.git
Fetching https://github.com/vapor/bits.git
Fetching https://github.com/vapor/debugging.git
Cloning https://github.com/vapor/node.git
Resolving https://github.com/vapor/node.git at 2.1.1
Cloning https://github.com/vapor/random.git
Resolving https://github.com/vapor/random.git at 1.2.0
Cloning https://github.com/vapor/core.git
Resolving https://github.com/vapor/core.git at 2.1.2
Cloning https://github.com/vapor/debugging.git
Resolving https://github.com/vapor/debugging.git at 1.1.0
Cloning https://github.com/vapor/bits.git
Resolving https://github.com/vapor/bits.git at 1.1.0
Cloning https://github.com/vapor/sockets.git
Resolving https://github.com/vapor/sockets.git at 2.1.0
Compile Swift Module 'Debugging' (1 sources)
Compile Swift Module 'PathIndexable' (2 sources)
Compile Swift Module 'libc' (1 sources)
Compile Swift Module 'Bits' (19 sources)
Compile Swift Module 'Core' (23 sources)
Compile Swift Module 'Random' (6 sources)
Compile Swift Module 'Transport' (10 sources)
Compile Swift Module 'Node' (38 sources)
Compile Swift Module 'Sockets' (22 sources)
Compile Swift Module 'Redis' (11 sources)

jmsmith@SF-M-JSMITH01 ~/w/B/redis (master)> swift test                                                                                                                  13:56:39
Compile Swift Module 'RedisTests' (1 sources)
Linking ./.build/x86_64-apple-macosx10.10/debug/RedisPackageTests.xctest/Contents/MacOS/RedisPackageTests
Test Suite 'All tests' started at 2017-09-27 13:57:05.218
Test Suite 'RedisPackageTests.xctest' started at 2017-09-27 13:57:05.218
Test Suite 'LiveTests' started at 2017-09-27 13:57:05.218
Test Case '-[RedisTests.LiveTests testData]' started.
Test Case '-[RedisTests.LiveTests testData]' passed (0.186 seconds).
Test Case '-[RedisTests.LiveTests testError]' started.
Test Case '-[RedisTests.LiveTests testError]' passed (0.002 seconds).
Test Case '-[RedisTests.LiveTests testHash]' started.
Test Case '-[RedisTests.LiveTests testHash]' passed (0.004 seconds).
Test Case '-[RedisTests.LiveTests testKeys]' started.
Test Case '-[RedisTests.LiveTests testKeys]' passed (0.002 seconds).
Test Case '-[RedisTests.LiveTests testPerformance]' started.
/Users/jmsmith/workspace/Baseline/redis/Tests/RedisTests/LiveTests.swift:105: Test Case '-[RedisTests.LiveTests testPerformance]' measured [Time, seconds] average: 1.133, relative standard deviation: 1.924%, values: [1.138196, 1.128330, 1.137279, 1.142048, 1.116332, 1.098309, 1.113999, 1.120190, 1.181370, 1.148989], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[RedisTests.LiveTests testPerformance]' passed (11.676 seconds).
Test Case '-[RedisTests.LiveTests testPing]' started.
Test Case '-[RedisTests.LiveTests testPing]' passed (0.001 seconds).
Test Case '-[RedisTests.LiveTests testPipeline]' started.
Test Case '-[RedisTests.LiveTests testPipeline]' passed (0.001 seconds).
Test Case '-[RedisTests.LiveTests testPubSub]' started.
Test Case '-[RedisTests.LiveTests testPubSub]' passed (0.002 seconds).
Test Case '-[RedisTests.LiveTests testString]' started.
Test Case '-[RedisTests.LiveTests testString]' passed (0.001 seconds).
Test Suite 'LiveTests' passed at 2017-09-27 13:57:17.093.
	 Executed 9 tests, with 0 failures (0 unexpected) in 11.875 (11.875) seconds
Test Suite 'RedisPackageTests.xctest' passed at 2017-09-27 13:57:17.093.
	 Executed 9 tests, with 0 failures (0 unexpected) in 11.875 (11.875) seconds
Test Suite 'All tests' passed at 2017-09-27 13:57:17.093.
	 Executed 9 tests, with 0 failures (0 unexpected) in 11.875 (11.876) seconds
```