### PR TITLE
Beta Package versions Fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,25 +3,25 @@
 import PackageDescription
 
 let package = Package(
-    name: "Redis",
-    products: [
-        .library(name: "Redis", targets: ["Redis"]),
-    ],
-    dependencies: [
-        // Swift Promises, Futures, and Streams.
-        .package(url: "https://github.com/vapor/async.git", .exact("1.0.0-beta.1")),
+  name: "Redis",
+  products: [
+    .library(name: "Redis", targets: ["Redis"]),
+  ],
+  dependencies: [
+    // Swift Promises, Futures, and Streams.
+    .package(url: "https://github.com/vapor/async.git", from: "1.0.0-beta"),
 
-        // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", .exact("3.0.0-beta.1")),
+    // Core extensions, type-aliases, and functions that facilitate common tasks.
+    .package(url: "https://github.com/vapor/core.git", from: "3.0.0-beta"),
 
-        // Non-blocking networking for Swift.
-        .package(url: "https://github.com/vapor/sockets.git", .exact("3.0.0-beta.1")),
+    // Non-blocking networking for Swift.
+    .package(url: "https://github.com/vapor/sockets.git", from: "3.0.0-beta"),
 
-        // Core services for creating database integrations.
-        .package(url: "https://github.com/vapor/database-kit.git", .exact("1.0.0-beta.1")),
-    ],
-    targets: [
-        .target(name: "Redis", dependencies: ["Async", "Bits", "DatabaseKit", "Debugging", "TCP"]),
-        .testTarget(name: "RedisTests", dependencies: ["Redis"]),
-    ]
+    // Core services for creating database integrations.
+    .package(url: "https://github.com/vapor/database-kit.git", from: "1.0.0-beta"),
+  ],
+  targets: [
+    .target(name: "Redis", dependencies: ["Async", "Bits", "DatabaseKit", "Debugging", "TCP"]),
+    .testTarget(name: "RedisTests", dependencies: ["Redis"]),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,16 @@ let package = Package(
   ],
   dependencies: [
     // Swift Promises, Futures, and Streams.
-    .package(url: "https://github.com/vapor/async.git", from: "1.0.0-beta"),
+    .package(url: "https://github.com/vapor/async.git",  "1.0.0-beta.1"..<"1.0.0-beta.1.1"),
 
     // Core extensions, type-aliases, and functions that facilitate common tasks.
-    .package(url: "https://github.com/vapor/core.git", from: "3.0.0-beta"),
+    .package(url: "https://github.com/vapor/core.git", "3.0.0-beta.1"..<"3.0.0-beta.1.1"),
 
     // Non-blocking networking for Swift.
-    .package(url: "https://github.com/vapor/sockets.git", from: "3.0.0-beta"),
+    .package(url: "https://github.com/vapor/sockets.git", "3.0.0-beta.1"..<"3.0.0-beta.2.1"),
 
     // Core services for creating database integrations.
-    .package(url: "https://github.com/vapor/database-kit.git", from: "1.0.0-beta"),
+    .package(url: "https://github.com/vapor/database-kit.git", "1.0.0-beta.1"..<"1.0.0-beta.3"),
   ],
   targets: [
     .target(name: "Redis", dependencies: ["Async", "Bits", "DatabaseKit", "Debugging", "TCP"]),


### PR DESCRIPTION
This change "relaxes" the dependencies of the Package so they could be used with current and future beta packages without the need to change. I am not sure if there is a more canonical way to structure PR's for the Vapor project if so refer me to the docs and I will happily restructure so that I can contribute more aptly to this community.