### PR TITLE
Auth fix

### DIFF
--- a/Sources/Redis/Client/RedisClient+connect.swift
+++ b/Sources/Redis/Client/RedisClient+connect.swift
@@ -25,7 +25,7 @@ extension RedisClient {
             if let password = password {
                 return client.authorize(with: password).map({ _ in client })
             }
-            return Future.map(on: worker, { client})
+            return Future.map(on: worker, { client })
         }
     }
 }

--- a/Sources/Redis/Client/RedisClient+connect.swift
+++ b/Sources/Redis/Client/RedisClient+connect.swift
@@ -6,6 +6,7 @@ extension RedisClient {
     public static func connect(
         hostname: String = "localhost",
         port: Int = 6379,
+        password: String? = nil,
         on worker: Worker,
         onError: @escaping (Error) -> Void
     ) -> Future<RedisClient> {
@@ -16,6 +17,8 @@ extension RedisClient {
             .channelInitializer { channel in
                 return channel.pipeline.addRedisHandlers().then {
                     channel.pipeline.add(handler: handler)
+                    }.then {
+                        
                 }
             }
 

--- a/Sources/Redis/Client/RedisClient.swift
+++ b/Sources/Redis/Client/RedisClient.swift
@@ -62,7 +62,7 @@ public final class RedisClient: DatabaseConnection, BasicWorker {
         guard !isClosed else {
             return eventLoop.newFailedFuture(error: closeError)
         }
-        
+
         // create a new promise and store it
         let promise = eventLoop.newPromise(Void.self)
         currentSend = promise

--- a/Sources/Redis/Database/RedisDatabase.swift
+++ b/Sources/Redis/Database/RedisDatabase.swift
@@ -13,14 +13,13 @@ public final class RedisDatabase: Database {
 
     /// See `Database`.
     public func newConnection(on worker: Worker) -> EventLoopFuture<RedisClient> {
-        return RedisClient.connect(hostname: config.hostname, port: config.port, on: worker) { error in
+        return RedisClient.connect(
+            hostname: config.hostname,
+            port: config.port,
+            password: config.password,
+            on: worker
+        ) { error in
             print("[Redis] \(error)")
-        }.then { client in
-            if let password = self.config.password {
-                return client.command("AUTH", [.basicString(password)]).transform(to: client)
-            } else {
-                return worker.eventLoop.newSucceededFuture(result: client)
-            }
         }
     }
 }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -8,7 +8,12 @@ extension RedisClient {
     static func makeTest() throws -> RedisClient {
         let group = MultiThreadedEventLoopGroup(numThreads: 1)
         let password = Environment.get("REDIS_PASSWORD")
-        let client = try RedisClient.connect(hostname: "localhost", port: 6379, password: password, on: group) { error in
+        let client = try RedisClient.connect(
+            hostname: "localhost",
+            port: 6379,
+            password: password,
+            on: group
+        ) { error in
             XCTFail("\(error)")
         }.wait()
         return client

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -33,7 +33,7 @@ class RedisTests: XCTestCase {
     }
 
     func testPubSubSingleChannel() throws {
-        let futureExpectation = expectation(description: "Subscriber should recevie message")
+        let futureExpectation = expectation(description: "Subscriber should receive message")
 
         let redisSubscriber = try RedisClient.makeTest()
         let redisPublisher = try RedisClient.makeTest()
@@ -62,8 +62,8 @@ class RedisTests: XCTestCase {
     func testPubSubMultiChannel() throws {
         let expectedChannel1Msg = "Stuff and things"
         let expectedChannel2Msg = "Stuff and things 3"
-        let futureExpectation1 = expectation(description: "Subscriber should recevie message \(expectedChannel1Msg)")
-        let futureExpectation2 = expectation(description: "Subscriber should recevie message \(expectedChannel2Msg)")
+        let futureExpectation1 = expectation(description: "Subscriber should receive message \(expectedChannel1Msg)")
+        let futureExpectation2 = expectation(description: "Subscriber should receive message \(expectedChannel2Msg)")
         let redisSubscriber = try RedisClient.makeTest()
         let redisPublisher = try RedisClient.makeTest()
         defer {

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -7,6 +7,7 @@ extension RedisClient {
     /// Creates a test event loop and Redis client.
     static func makeTest() throws -> RedisClient {
         let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        
         let client = try RedisClient.connect(hostname: "localhost", port: 6379, on: group) { error in
             XCTFail("\(error)")
         }.wait()

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,8 @@ jobs:
      steps:
        - checkout
        - run: swiftlint --strict
-  authlinux:
+  #authlinux:
+  build:
     docker:
       - image: codevapor/swift:4.1
       - image: redis:3.2

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,8 @@ jobs:
      steps:
        - checkout
        - run: swiftlint --strict
-  authlinux:
+  #authlinux:
+  build:
     docker:
       - image: codevapor/swift:4.1
       - image: redis:3.2

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,9 @@ jobs:
      steps:
        - checkout
        - run: swiftlint --strict
-  authlinux:
+       
+
+  linux-auth:
     docker:
       - image: codevapor/swift:4.1
       - image: redis:3.2
@@ -55,7 +57,7 @@ workflows:
   tests:
     jobs:
       - linux
-      - swiftlint
-      - authlinux
+      - linux-auth
       - linux-release
+      - swiftlint
       # - macos

--- a/circle.yml
+++ b/circle.yml
@@ -23,10 +23,24 @@ jobs:
      steps:
        - checkout
        - run: swiftlint --strict
+  authlinux:
+    docker:
+      - image: codevapor/swift:4.1
+      - image: redis:3.2
+        command: >
+          --slaveof 10.0.0.2 6379
+          --requirepass secret
+    steps:
+      - checkout
+      - run: swift build
+      - run: swift test
+      - run: swift build -c release
+    
 workflows:
   version: 2
   tests:
     jobs:
       - linux
       - swiftlint
+      - authlinux
       # - macos

--- a/circle.yml
+++ b/circle.yml
@@ -59,5 +59,5 @@ workflows:
       - linux
       - linux-auth
       - linux-release
-      - swiftlint
+      # - swiftlint
       # - macos

--- a/circle.yml
+++ b/circle.yml
@@ -34,8 +34,7 @@ jobs:
      steps:
        - checkout
        - run: swiftlint --strict
-  #authlinux:
-  build:
+  authlinux:
     docker:
       - image: codevapor/swift:4.1
       - image: redis:3.2


### PR DESCRIPTION
- Modified Test Suite to make use of redis_password if environment makes use of it
- Modified CircleCI file to use an auth environment
- Modified Test Suite to use @MrMage's revelation of `waitForExpectations`
- Cleaned up some whitespace to enable swiftlint strict to run again

- resolve #105 
- resolve #107
