### PR TITLE
Add SELECT command and config conveniences

### DIFF
--- a/Sources/Redis/Client/Redis+Commands.swift
+++ b/Sources/Redis/Client/Redis+Commands.swift
@@ -207,4 +207,7 @@ extension RedisClient {
         return command("RPOPLPUSH", [RedisData(bulk: source), RedisData(bulk: destination)])
     }
 
+    public func select(_ database: Int) -> Future<RedisData> {
+        return command("SELECT", [RedisData(bulk: database.description)])
+    }
 }

--- a/Sources/Redis/Client/RedisClient.swift
+++ b/Sources/Redis/Client/RedisClient.swift
@@ -104,11 +104,16 @@ public struct RedisClientConfig: Codable {
     /// The Redis server's optional password.
     public var password: String?
 
+    /// The database to connect to automatically.
+    /// If nil, the connection will use the default 0.
+    public var database: Int?
+
     /// Create a new `RedisClientConfig`
     public init(url: URL) {
         self.hostname = url.host ?? "localhost"
         self.port = url.port ?? 6379
         self.password = url.password
+        self.database = Int(url.path)
     }
 
     public init() {
@@ -118,10 +123,18 @@ public struct RedisClientConfig: Codable {
 
     internal func toURL() throws -> URL {
         let urlString: String
-        if let password = password {
-            urlString = "redis://:\(password)@\(hostname):\(port)"
+        let databaseSuffix: String
+
+        if let database = database {
+            databaseSuffix = "/\(database)"
         } else {
-            urlString = "redis://\(hostname):\(port)"
+            databaseSuffix = ""
+        }
+
+        if let password = password {
+            urlString = "redis://:\(password)@\(hostname)\(databaseSuffix):\(port)"
+        } else {
+            urlString = "redis://\(hostname)\(databaseSuffix):\(port)"
         }
 
         guard let url = URL(string: urlString) else {

--- a/Sources/Redis/Database/RedisDatabase.swift
+++ b/Sources/Redis/Database/RedisDatabase.swift
@@ -13,13 +13,22 @@ public final class RedisDatabase: Database {
 
     /// See `Database`.
     public func newConnection(on worker: Worker) -> EventLoopFuture<RedisClient> {
-        return RedisClient.connect(
+        let connect = RedisClient.connect(
             hostname: config.hostname,
             port: config.port,
             password: config.password,
             on: worker
         ) { error in
             print("[Redis] \(error)")
+        }
+
+        guard let database = config.database else {
+            return connect
+        }
+
+        return connect.flatMap { client in
+            client.select(database)
+                .transform(to: client)
         }
     }
 }

--- a/Tests/RedisTests/RedisDatabaseTests.swift
+++ b/Tests/RedisTests/RedisDatabaseTests.swift
@@ -1,0 +1,84 @@
+import NIO
+import Dispatch
+@testable import Redis
+import XCTest
+
+private extension RedisClientConfig {
+    static func makeTest() -> RedisClientConfig {
+        var config = RedisClientConfig()
+        config.password = Environment.get("REDIS_PASSWORD")
+        return config
+    }
+}
+
+class RedisDatabaseTests: XCTestCase {
+    let defaultTimeout = 2.0
+
+    func testConnection() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let config = RedisClientConfig.makeTest()
+        let database = try RedisDatabase(config: config)
+        let redis = try database.newConnection(on: group).wait()
+        defer { redis.close() }
+        try redis.set("hello", to: "world").wait()
+        let get = try redis.get("hello", as: String.self).wait()
+        XCTAssertEqual(get, "world")
+        try redis.delete("hello").wait()
+        XCTAssertNil(try redis.get("hello", as: String.self).wait())
+    }
+
+    func testSelect() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let config = RedisClientConfig.makeTest()
+        let database = try RedisDatabase(config: config)
+
+        let redis = try database.newConnection(on: group).wait()
+        defer { redis.close() }
+
+        _ = try redis.select(2).wait()
+        try redis.set("hello", to: "world").wait()
+        let get = try redis.get("hello", as: String.self).wait()
+        XCTAssertEqual(get, "world")
+
+        _ = try redis.select(0).wait()
+        XCTAssertNil(try redis.get("hello", as: String.self).wait())
+
+        _ = try redis.select(2).wait()
+        let reget = try redis.get("hello", as: String.self).wait()
+        XCTAssertEqual(reget, "world")
+
+        try redis.delete("hello").wait()
+        XCTAssertNil(try redis.get("hello", as: String.self).wait())
+    }
+
+    func testSelectViaConfig() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        var config = RedisClientConfig.makeTest()
+        config.database = 2
+
+        let database = try RedisDatabase(config: config)
+
+        let redis = try database.newConnection(on: group).wait()
+        defer { redis.close() }
+
+        try redis.set("hello", to: "world").wait()
+        let get = try redis.get("hello", as: String.self).wait()
+        XCTAssertEqual(get, "world")
+
+        _ = try redis.select(0).wait()
+        XCTAssertNil(try redis.get("hello", as: String.self).wait())
+
+        _ = try redis.select(2).wait()
+        let reget = try redis.get("hello", as: String.self).wait()
+        XCTAssertEqual(reget, "world")
+
+        try redis.delete("hello").wait()
+        XCTAssertNil(try redis.get("hello", as: String.self).wait())
+    }
+
+    static let allTests = [
+        ("testConnection", testConnection),
+        ("testSelect", testSelect),
+        ("testSelectViaConfig", testSelectViaConfig),
+    ]
+}


### PR DESCRIPTION
Pretty much what it says on the tin, this PR:
- Adds a `select(_ database: Int)` command to RedisClient for [SELECT](https://redis.io/commands/select).
- Adds a `database: Int?` field to RedisClientConfig. When set, RedisDatabase now preselects this database before returning the client.
- Adds support for configuring the default database via the Redis URL's path (as seen in other languages).
- Adds some tests.

Resolves #114.