### PR TITLE
maybe register the redis for KeyedCache ?

### DIFF
--- a/Sources/Redis/RedisProvider.swift
+++ b/Sources/Redis/RedisProvider.swift
@@ -18,6 +18,11 @@ public final class RedisProvider: Provider {
         var databases = DatabasesConfig()
         databases.add(database: RedisDatabase.self, as: .redis)
         services.register(databases)
+        
+        services.register(KeyedCache.self) { container -> RedisCache in
+            let pool = try container.connectionPool(to: .redis)
+            return .init(pool: pool)
+        }
     }
 
     /// See `Provider.boot`
@@ -39,3 +44,5 @@ extension RedisDatabase: ServiceType {
         return try .init(config: worker.make())
     }
 }
+
+public typealias RedisCache = DatabaseKeyedCache<ConfiguredDatabase<RedisDatabase>>

--- a/Sources/Redis/RedisProvider.swift
+++ b/Sources/Redis/RedisProvider.swift
@@ -7,7 +7,7 @@ public final class RedisProvider: Provider {
     /// See `Provider.repositoryName`
     public static let repositoryName = "redis"
 
-    /// Creates a new `PostgreSQLProvider`.
+    /// Creates a new `RedisProvider`.
     public init() {}
 
     /// See `Provider.register`


### PR DESCRIPTION
fix error for example as inside SQLiteProvider:
```
Service Error: No service DatabaseKeyedCache<ConfiguredDatabase<RedisDatabase>> 
has been registered for 'KeyedCache'.
```