### PR TITLE
Add failing test for EXPIRE and fix it too

### DIFF
--- a/Sources/Redis/Client/Redis+Commands.swift
+++ b/Sources/Redis/Client/Redis+Commands.swift
@@ -39,12 +39,13 @@ extension RedisClient {
     ///
     /// https://redis.io/commands/expire
     public func expire(_ key: String, after deadline: Int) -> Future<Int> {
-        let resp = command("EXPIRE", [RedisData(stringLiteral:key), RedisData(integerLiteral: deadline)]).map(to: Int.self) { data in
-            guard let value = data.int else {
-                throw RedisError(identifier: "expire", reason: "Could not convert resp to in.t")
-            }
+        let resp = command("EXPIRE", [RedisData(stringLiteral: key), RedisData(bulk: deadline.description)])
+            .map(to: Int.self) { data in
+                guard let value = data.int else {
+                    throw RedisError(identifier: "expire", reason: "Could not convert resp to int")
+                }
 
-            return value
+                return value
         }
 
         return resp

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -162,12 +162,25 @@ class RedisTests: XCTestCase {
         _ = try redis.delete(["mylist", "list2"]).wait()
     }
 
+    func testExpire() throws {
+        let redis = try RedisClient.makeTest()
+        defer { redis.close() }
+        _ = try redis.command("FLUSHALL").wait()
+
+        try redis.set("foo", to: "bar").wait()
+        XCTAssertEqual(try redis.get("foo", as: String.self).wait(), "bar")
+        _ = try redis.expire("foo", after: 1).wait()
+        sleep(2)
+        XCTAssertEqual(try redis.get("foo", as: String.self).wait(), nil)
+    }
+
     static let allTests = [
         ("testCRUD", testCRUD),
         ("testPubSubSingleChannel", testPubSubSingleChannel),
         ("testPubSubMultiChannel", testPubSubMultiChannel),
         ("testStruct", testStruct),
         ("testStringCommands", testStringCommands),
-        ("testListCommands", testListCommands)
+        ("testListCommands", testListCommands),
+        ("testExpire", testExpire),
     ]
 }


### PR DESCRIPTION
Calling `expire` in the current tagged version throws an error: `⚠️ Redis Error: ERR Protocol error: expected '$', got ':'`, which means that the expiration time is expected as a bulk string, not as an integer literal on the wire.

This PR adds a test and fixes the issue.