### PR TITLE
Support null arrays

### DIFF
--- a/Sources/Redis/Coders/RedisDataDecoder.swift
+++ b/Sources/Redis/Coders/RedisDataDecoder.swift
@@ -66,6 +66,7 @@ fileprivate extension RedisDataDecoder {
 
     private func parseArray(at position: inout Int, from buffer: ByteBuffer) throws -> PartialRedisData {
         guard let arraySize = try integer(at: &position, from: buffer) else { return .notYetParsed }
+        guard arraySize > -1 else { return .parsed(.null) }
 
         var array = [PartialRedisData](repeating: .notYetParsed, count: arraySize)
         for index in 0..<arraySize {


### PR DESCRIPTION
Had some crashes occur when the client was trying to parse a null array and you can't create an array of length -1 😅. 

From the [RESP docs](https://redis.io/topics/protocol#resp-arrays):

> ```"*-1\r\n"```
>
> A client library API should return a null object and not an empty Array when Redis replies with a Null Array. This is necessary to distinguish between an empty list and a different condition (for instance the timeout condition of the BLPOP command).