### PR TITLE
Fix conversion from RedisData for FixedWidthInteger

### DIFF
--- a/Sources/Redis/Data/RedisDataConvertible.swift
+++ b/Sources/Redis/Data/RedisDataConvertible.swift
@@ -116,3 +116,19 @@ extension Data: RedisDataConvertible {
         return .bulkString(self)
     }
 }
+
+extension Array: RedisDataConvertible where Element: RedisDataConvertible {
+    /// See `RedisDataConvertible`.
+    public static func convertFromRedisData(_ data: RedisData) throws -> Array<Element> {
+        guard let array = data.array else {
+            throw RedisError(identifier: "array", reason: "Could not convert to array: \(data).")
+        }
+        return try array.map { try Element.convertFromRedisData($0) }
+    }
+
+    /// See `RedisDataConvertible`.
+    public func convertToRedisData() throws -> RedisData {
+        let dataArray = try map { try $0.convertToRedisData() }
+        return RedisData.array(dataArray)
+    }
+}

--- a/Sources/Redis/Data/RedisDataConvertible.swift
+++ b/Sources/Redis/Data/RedisDataConvertible.swift
@@ -40,8 +40,17 @@ extension FixedWidthInteger {
     /// See `RedisDataConvertible`.
     public static func convertFromRedisData(_ data: RedisData) throws -> Self {
         guard let int = data.int else {
-            throw RedisError(identifier: "int", reason: "Could not convert to int: \(data).")
+            guard let string = data.string else {
+                throw RedisError(identifier: "string", reason: "Could not convert to string: \(data)")
+            }
+
+            guard let int = Self(string) else {
+                throw RedisError(identifier: "int", reason: "Could not convert to int: \(data)")
+            }
+
+            return int
         }
+
         return Self(int)
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,5 +2,9 @@ import XCTest
 @testable import RedisTests
 
 XCTMain([
-	testCase(RedisTests.allTests)
+	testCase(RedisTests.allTests),
+    testCase(RedisDataDecoderTests.allTests),
+    testCase(RedisDataEncoderTests.allTests),
+    testCase(RedisDatabaseTests.allTests),
+    testCase(RedisDataConvertibleTests.allTests)
 ])

--- a/Tests/RedisTests/RedisDataConvertibleTests.swift
+++ b/Tests/RedisTests/RedisDataConvertibleTests.swift
@@ -28,8 +28,22 @@ class RedisDataConvertibleTests: XCTestCase {
         XCTAssertThrowsError(try Array<Int>.convertFromRedisData(data))
     }
 
+    func testIntToRedisData() throws {
+        let data = try RedisData(integerLiteral: 300).convertToRedisData()
+        XCTAssertNotNil(data.int)
+    }
+
+    func testIntFromData() throws {
+        var data = try Int.convertFromRedisData(RedisData(stringLiteral: "3"))
+        XCTAssertEqual(data, 3)
+        data = try .convertFromRedisData(1.convertToRedisData())
+        XCTAssertEqual(data, 1)
+    }
+
     static let allTests = [
         ("testArrayToRedisData", testArrayToRedisData),
         ("testArrayFromData", testArrayFromData),
+        ("testIntToRedisData", testIntToRedisData),
+        ("testIntFromData", testIntFromData),
     ]
 }

--- a/Tests/RedisTests/RedisDataConvertibleTests.swift
+++ b/Tests/RedisTests/RedisDataConvertibleTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+@testable import Redis
+import XCTest
+
+class RedisDataConvertibleTests: XCTestCase {
+    func testArrayToRedisData() throws {
+        let data = try [
+            RedisData(integerLiteral: 3),
+            RedisData(integerLiteral: 1),
+            RedisData(stringLiteral: "Some string")
+        ].convertToRedisData()
+
+        XCTAssertNotNil(data.array)
+        XCTAssertEqual(data.array?[0].int, 3)
+        XCTAssertEqual(data.array?[1].int, 1)
+        XCTAssertEqual(data.array?[2].string, "Some string")
+    }
+
+    func testArrayFromData() throws {
+        var data = RedisData(arrayLiteral: .integer(3), .integer(1))
+        let results: [Int] = try .convertFromRedisData(data)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0], 3)
+        XCTAssertEqual(results[1], 1)
+
+        data = RedisData(arrayLiteral: .integer(2), .bulkString("Vapor"), .null)
+        XCTAssertThrowsError(try Array<Int>.convertFromRedisData(data))
+    }
+
+    static let allTests = [
+        ("testArrayToRedisData", testArrayToRedisData),
+        ("testArrayFromData", testArrayFromData),
+    ]
+}


### PR DESCRIPTION
This brings `FixedWidthInteger` in alignment with implementation for `Float` and `Double` by providing a fallback conversion from string