### PR TITLE
Pipelining

### DIFF
--- a/Sources/Redis/Client/RedisClient+Pipeline.swift
+++ b/Sources/Redis/Client/RedisClient+Pipeline.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+extension RedisClient {
+    /// Creates a `RedisPipeline` for executing a batch of commands.
+    public func makePipeline() -> RedisPipeline {
+        return .init(client: self)
+    }
+}
+
+/// An object that provides a mechanism to "pipeline" multiple Redis commands in sequence providing an aggregate response
+/// of all the responses of each individual command.
+///
+///     let results = connection.makePipeline()
+///         .enqueue(command: "SET", arguments: ["my_key", 3])
+///         .enqueue(command: "INCR", arguments: ["my_key"])
+///         .execute()
+///     // results == Future<[RedisData]>
+///     // results[0].string == "OK"
+///     // results[1].int == 4
+///
+public final class RedisPipeline {
+    /// The client to execute the commands on.
+    private let client: RedisClient
+
+    /// The queue of complete encoded commands to execute.
+    private var queue: [RedisData]
+
+    internal init(client: RedisClient) {
+        self.client = client
+        self.queue = []
+    }
+
+    /// Queues the provided command and arguments to be executed.
+    /// - Parameters:
+    ///     - command: The command to execute. See https://redis.io/commands
+    ///     - arguments: The arguments, if any, to send with the command.
+    /// - Returns: A self-reference to this `RedisPipeline` instance for chaining commands.
+    public func enqueue(command: String, arguments: [RedisDataConvertible] = []) throws -> RedisPipeline {
+        let args = try arguments.map { try $0.convertToRedisData() }
+
+        queue.append(.array([.bulkString(command)] + args))
+
+        return self
+    }
+
+    /// Drains the queue, executing each command in sequence.
+    /// - Important: If any of the commands fail, the entire future will fail.
+    /// - Returns: A `Future` that resolves the `RedisData` responses, in the same order as the command queue.
+    public func execute() -> Future<[RedisData]> {
+        let promise = client.eventLoop.newPromise([RedisData].self)
+
+        var results = [RedisData]()
+        var iterator = queue.makeIterator()
+
+        func handle(_ command: RedisData) {
+            let future = client.send(command)
+            future.whenSuccess { response in
+                switch response.storage {
+                case let .error(error): promise.fail(error: error)
+                default:
+                    results.append(response)
+
+                    if let next = iterator.next() {
+                        handle(next)
+                    } else {
+                        promise.succeed(result: results)
+                    }
+                }
+            }
+            future.whenFailure { promise.fail(error: $0) }
+        }
+
+        if let first = iterator.next() {
+            handle(first)
+        } else {
+            promise.succeed(result: [])
+        }
+
+        return promise.futureResult
+            .always { self.queue = [] }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,5 +2,9 @@ import XCTest
 @testable import RedisTests
 
 XCTMain([
-	testCase(RedisTests.allTests)
+    testCase(RedisTests.allTests),
+    testCase(RedisDatabaseTests.allTests),
+    testCase(RedisDataEncoderTests.allTests),
+    testCase(RedisDataDecoderTests.allTests),
+    testCase(RedisPipelineTests.allTests)
 ])

--- a/Tests/RedisTests/RedisPipelineTests.swift
+++ b/Tests/RedisTests/RedisPipelineTests.swift
@@ -1,0 +1,78 @@
+import Dispatch
+import NIO
+@testable import Redis
+import XCTest
+
+private extension RedisClientConfig {
+    static func makeTest() -> RedisClientConfig {
+        var config = RedisClientConfig()
+        config.password = Environment.get("REDIS_PASSWORD")
+        return config
+    }
+}
+
+internal class RedisPipelineTests: XCTestCase {
+    var connection: RedisClient!
+
+    override func setUp() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let config = RedisClientConfig.makeTest()
+
+        guard
+            let database = try? RedisDatabase(config: config),
+            let conn = try? database.newConnection(on: group).wait()
+        else {
+            return XCTFail("Failed to properly setup Redis connection!")
+        }
+
+        connection = conn
+    }
+
+    override func tearDown() {
+        _ = try? connection?.command("FLUSHALL").wait()
+        connection?.close()
+    }
+
+    func testEnqueue() {
+        let pipeline = connection.makePipeline()
+
+        XCTAssertNoThrow(try pipeline.enqueue(command: "PING"))
+        XCTAssertNoThrow(try pipeline.enqueue(command: "SET", arguments: ["KEY", "VALUE"]))
+    }
+
+    func testExecuteFails() throws {
+        let pipeline = try connection.makePipeline()
+            .enqueue(command: "GET")
+
+        XCTAssertThrowsError(try pipeline.execute().wait())
+    }
+
+    func testExecuteSucceeds() throws {
+        let results = try connection.makePipeline()
+            .enqueue(command: "SET", arguments: ["key", "value"])
+            .execute().wait()
+
+        XCTAssertEqual(results.count, 1)
+    }
+
+    func testExecuteIsOrdered() throws {
+        let results = try connection.makePipeline()
+            .enqueue(command: "SET", arguments: ["key", 1])
+            .enqueue(command: "INCR", arguments: ["key"])
+            .enqueue(command: "DECR", arguments: ["key"])
+            .enqueue(command: "INCRBY", arguments: ["key", 15])
+            .execute().wait()
+
+        XCTAssertEqual(results[0].string, "OK")
+        XCTAssertEqual(results[1].int, 2)
+        XCTAssertEqual(results[2].int, 1)
+        XCTAssertEqual(results[3].int, 16)
+    }
+
+    static let allTests = [
+        ("testEnqueue", testEnqueue),
+        ("testExecuteFails", testExecuteFails),
+        ("testExecuteSucceeds", testExecuteSucceeds),
+        ("testExecuteIsOrdered", testExecuteIsOrdered),
+    ]
+}


### PR DESCRIPTION
This should address #85 and #111.

This gives the behavior of pipelining requests, and wraps around the constraint of a single request at a time by `QueueHandler` in Core. This also removes the need for users to have to implement Lazy Futures on their own.

EDIT: I previously mentioned "true pipelining", linking to the [pipelining](https://redis.io/topics/pipelining) documentation, but now after working a bit more to implement "true pipelining" I've come to understand that this is all client-side.

I'm leaving it as is - as the current implementation provides a pipelining mechanism, but there are ways to improve the memory footprint of this.