### PR TITLE
fix queue handler extra message warning

### DIFF
--- a/Sources/Redis/Coders/RedisDataDecoder.swift
+++ b/Sources/Redis/Coders/RedisDataDecoder.swift
@@ -33,6 +33,11 @@ final class RedisDataDecoder: ByteToMessageDecoder {
             return .continue
         }
     }
+    
+    public func decodeLast(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+        // ignore
+        return .needMoreData
+    }
 }
 
 fileprivate extension RedisDataDecoder {

--- a/Sources/Redis/Data/RedisData.swift
+++ b/Sources/Redis/Data/RedisData.swift
@@ -103,6 +103,31 @@ public struct RedisData {
     }
 }
 
+extension RedisData.Storage: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .array(let array):
+            return array.description
+        case .basicString(let string):
+            return string.debugDescription
+        case .bulkString(let data):
+            return String(data: data, encoding: .utf8).flatMap { $0.debugDescription } ?? "<n/a>"
+        case .error(let error):
+            return error.description
+        case .integer(let int):
+            return int.description
+        case .null:
+            return "NULL"
+        }
+    }
+}
+
+extension RedisData: CustomStringConvertible {
+    public var description: String {
+        return self.storage.description
+    }
+}
+
 extension RedisData: ExpressibleByStringLiteral {
     /// Initializes a bulk string from a String literal
     public init(stringLiteral value: String) {


### PR DESCRIPTION
- Fixes warning:

```
[WARNING] [Async] [QueueHandler] Read triggered when input queue was empty, ignoring: RedisData
```

- Adds `CustomStringConvertible` conformance to `RedisData`. 