### PR TITLE
Remove currentSend check to let the requests get enqueued

### DIFF
--- a/Tests/RedisTests/RedisDatabaseTests.swift
+++ b/Tests/RedisTests/RedisDatabaseTests.swift
@@ -85,13 +85,16 @@ class RedisDatabaseTests: XCTestCase {
         let database = try RedisDatabase(config: config)
         let redis = try database.newConnection(on: group).wait()
 
-        let future1 = redis.get("hello", as: String.self)
-        let future2 = redis.get("hello", as: String.self)
+        try redis.set("hello1", to: "foo").wait()
+        try redis.set("hello2", to: "bar").wait()
+
+        let future1 = redis.get("hello1", as: String.self)
+        let future2 = redis.get("hello2", as: String.self)
 
         future1.and(future2)
             .do {
-                XCTAssertNil($0)
-                XCTAssertNil($1)
+                XCTAssertEqual("foo", $0)
+                XCTAssertEqual("bar", $1)
                 exp.fulfill()
             }
             .catch {


### PR DESCRIPTION
Fixes #111. I'm not 100% certain that this is universally correct, but tests still check out, including a new test that previously crashed.

Sidenote, it seems `RedisTests.testPubSubSingleChannel` is not deterministic.