### PR TITLE
Update to Vapor and RedisKit 4.0 Beta 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,15 @@ import PackageDescription
 
 let package = Package(
     name: "redis",
+    platforms: [
+        .macOS(.v10_14)
+    ],
     products: [
         .library(name: "Redis", targets: ["Redis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/redis-kit.git", from: "1.0.0-alpha"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-alpha.1.4"),
+        .package(url: "https://github.com/vapor/redis-kit.git", from: "1.0.0-beta.1"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.1"),
     ],
     targets: [
       .target(name: "Redis", dependencies: ["RedisKit", "Vapor"]),

--- a/Sources/Redis/RedisProvider.swift
+++ b/Sources/Redis/RedisProvider.swift
@@ -9,10 +9,15 @@ public struct RedisProvider: Provider {
         }
 
         app.register(singleton: ConnectionPool<RedisConnectionSource>.self, boot: { app in
-            return ConnectionPool(configuration: app.make(), source: app.make(), logger: app.make(Logger.self), on: app.make())
-        }) { pool in
+            return ConnectionPool(
+                configuration: app.make(),
+                source: app.make(),
+                logger: app.make(Logger.self),
+                on: app.make()
+            )
+        }, shutdown: { pool in
             return pool.shutdown()
-        }
+        })
 
         app.register(RedisClient.self) { app in
             return app.make(ConnectionPool<RedisConnectionSource>.self)


### PR DESCRIPTION
Updating to the [provider changes](https://github.com/vapor/vapor/releases/tag/4.0.0-beta.1) in Vapor 4.0 Beta 1, and some related API changes in RedisKit.
