### PR TITLE
Beta 4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@ import PackageDescription
 let package = Package(
     name: "redis",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_15)
     ],
     products: [
         .library(name: "Redis", targets: ["Redis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/redis-kit.git", from: "1.0.0-beta.2"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.2.1"),
+        .package(url: "https://github.com/vapor/redis-kit.git", from: "1.0.0-beta.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [
       .target(name: "Redis", dependencies: ["RedisKit", "Vapor"]),


### PR DESCRIPTION
- Match Vapor's new minimum OS requirement
- Bump minimum required versions of dependencies
- Major beta server due to compatibility break of new minimum OS requirement. There are no actual changes to Redis itself.