### PR TITLE
add config option for connection retry timeout

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Redis", targets: ["Redis"])
     ],
     dependencies: [
-        .package(url: "https://gitlab.com/mordil/RediStack.git", from: "1.0.0-beta.1"),
+        .package(url: "https://gitlab.com/mordil/RediStack.git", from: "1.0.0-rc.2"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [

--- a/Sources/Redis/Application+Redis.swift
+++ b/Sources/Redis/Application+Redis.swift
@@ -56,7 +56,8 @@ extension Application {
                         connectionTCPClient: nil,
                         poolLogger: self.application.logger,
                         connectionBackoffFactor: configuration.pool.connectionBackoffFactor,
-                        initialConnectionBackoffDelay: configuration.pool.initialConnectionBackoffDelay
+                        initialConnectionBackoffDelay: configuration.pool.initialConnectionBackoffDelay,
+                        connectionRetryTimeout: configuration.pool.connectionRetryTimeout
                     )
                 }
                 self.application.storage.set(PoolKey.self, to: pools) { pools in

--- a/Sources/Redis/RedisConfiguration.swift
+++ b/Sources/Redis/RedisConfiguration.swift
@@ -14,17 +14,20 @@ public struct RedisConfiguration {
         public var minimumConnectionCount: Int
         public var connectionBackoffFactor: Float32
         public var initialConnectionBackoffDelay: TimeAmount
+        public var connectionRetryTimeout: TimeAmount?
 
         public init(
             maximumConnectionCount: RedisConnectionPoolSize = .maximumActiveConnections(2),
             minimumConnectionCount: Int = 0,
             connectionBackoffFactor: Float32 = 2,
-            initialConnectionBackoffDelay: TimeAmount = .milliseconds(100)
+            initialConnectionBackoffDelay: TimeAmount = .milliseconds(100),
+            connectionRetryTimeout: TimeAmount? = nil
         ) {
             self.maximumConnectionCount = maximumConnectionCount
             self.minimumConnectionCount = minimumConnectionCount
             self.connectionBackoffFactor = connectionBackoffFactor
             self.initialConnectionBackoffDelay = initialConnectionBackoffDelay
+            self.connectionRetryTimeout = connectionRetryTimeout
         }
     }
 


### PR DESCRIPTION
Add support for changing the connection retry timeout from the default of "immediately" to any `NIO.TimeAmount`

This is configurable on the `RedisConfiguration.pool` property:

```swift
// wait 5 seconds while the pool tries to find an available connection before failing commands
app.redis.configuration?.pool.connectionRetryTimeout = .seconds(5)
```