### PR TITLE
Change from using `path` to `lastPathComponent` in RedisConfiguration

### DIFF
--- a/Sources/Redis/RedisConfiguration.swift
+++ b/Sources/Redis/RedisConfiguration.swift
@@ -49,7 +49,7 @@ public struct RedisConfiguration {
             hostname: url.host ?? "localhost",
             port: url.port ?? RedisConnection.defaultPort,
             password: url.password,
-            database: Int(url.path),
+            database: Int(url.lastPathComponent),
             pool: pool
         )
     }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -36,7 +36,19 @@ class RedisTests: XCTestCase {
             XCTAssertContains(res.body.string, "redis_version")
         }
     }
+    
+    func testInitConfigurationURL() throws {
+        let app = Application()
+        defer { app.shutdown() }
 
+        let urlStr = URL(string: "redis://name:password@localhost:6379/0")
+        
+        let redisConfigurations = try RedisConfiguration(url: urlStr!)
+        
+        XCTAssertEqual(redisConfigurations.password, "password")
+        XCTAssertEqual(redisConfigurations.database, 0)
+    }
+    
     override class func setUp() {
         XCTAssert(isLoggingConfigured)
     }


### PR DESCRIPTION
Fix parsing the database index by using `lastPathComponent` to remove trailing `/`