### PR TITLE
Use swift 4.0.0 instead of 4.0.0-beta in Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://gitlab.com/mordil/RediStack.git", from: "1.0.0-rc.2"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Rely on Vapor 4.0.0 release rather than beta version