### PR TITLE
Change semantics of Redis sessions with key and ID generation

### DIFF
--- a/Sources/Redis/Redis+Sessions.swift
+++ b/Sources/Redis/Redis+Sessions.swift
@@ -6,21 +6,30 @@ public protocol RedisSessionsDelegate {
     /// Makes a new session ID token.
     /// - Note: This method is optional to implement.
     ///
-    ///  The default implementation creates 32 bytes of random data, base64 encodes it, and prefixes it with `vrs-`.
+    ///  The default implementation creates 32 bytes of random data and base64 encodes it.
     func makeNewID() -> SessionID
+    /// Makes a key to identify the given session ID in Redis.
+    /// - Note: This method is optional to implement.
+    ///
+    /// The default implementation prefixes the `sessionID` with `vrs-`.
+    /// - Parameter sessionID: The session ID that needs to be transformed into a `RediStack.RedisKey` for storage in Redis.
+    /// - Returns: A Redis key for the given `sessionID` to be used to identify associated `SessionData` in Redis.
+    func makeRedisKey(for sessionID: SessionID) -> RedisKey
     /// Instructs your delegate object to handle the responsibility of storing the provided session data to Redis.
     /// - Parameters:
     ///     - client: The Redis client to use for the operation.
     ///     - data: The session data to store in Redis.
-    ///     - id: The session ID to use to identify the data.
+    ///     - key: The Redis key to identify the data being stored.
     /// - Returns: A notification `NIO.EventLoopFuture` that resolves when the operation has completed.
-    func redis<Client: RedisClient>(_ client: Client, storeData data: SessionData, forID id: SessionID) -> EventLoopFuture<Void>
-    /// Asks the delegate object to fetch session data for a given session id.
+    @inlinable
+    func redis<Client: RedisClient>(_ client: Client, store data: SessionData, with key: RedisKey) -> EventLoopFuture<Void>
+    /// Asks the delegate object to fetch session data for a given Redis key.
     /// - Parameters:
     ///     - client: The Redis client to use for the operation.
-    ///     - id: The session ID to fetch data for from Redis.
-    /// - Returns: A `NIO.EventLoopFuture` that possibly resolves the available session data for the given session ID.
-    func redis<Client: RedisClient>(_ client: Client, fetchDataForID id: SessionID) -> EventLoopFuture<SessionData?>
+    ///     - key: The Redis key that identifies the data to be fetched.
+    /// - Returns: A `NIO.EventLoopFuture` that possibly resolves the available session data for the given Redis key.
+    @inlinable
+    func redis<Client: RedisClient>(_ client: Client, fetchDataFor key: RedisKey) -> EventLoopFuture<SessionData?>
 }
 
 extension RedisSessionsDelegate {
@@ -29,7 +38,11 @@ extension RedisSessionsDelegate {
         for _ in 0..<32 {
             bytes.append(.random(in: .min ..< .max))
         }
-        return .init(string: "vrs-\(bytes.base64EncodedString())")
+        return .init(string: bytes.base64EncodedString())
+    }
+    
+    public func makeRedisKey(for session: SessionID) -> RedisKey {
+        return "vrs-\(session.string)"
     }
 }
 
@@ -68,33 +81,39 @@ private struct RedisSessionsDriver: SessionDriver {
 
     func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let id = self.delegate.makeNewID()
+        let key = self.delegate.makeRedisKey(for: id)
         return self.delegate
-            .redis(request.redis, storeData: data, forID: id)
+            .redis(request.redis, store: data, with: key)
             .map { id }
     }
     
     func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
-        return self.delegate.redis(request.redis, fetchDataForID: sessionID)
+        let key = self.delegate.makeRedisKey(for: sessionID)
+        return self.delegate.redis(request.redis, fetchDataFor: key)
     }
     
     func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
+        let key = self.delegate.makeRedisKey(for: sessionID)
         return self.delegate
-            .redis(request.redis, storeData: data, forID: sessionID)
+            .redis(request.redis, store: data, with: key)
             .map { sessionID }
     }
     
     func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
-        return request.redis.delete("\(sessionID.string)").map { _ in () }
+        let key = self.delegate.makeRedisKey(for: sessionID)
+        return request.redis.delete(key).map { _ in () }
     }
 }
 
 // MARK: Default SessionsDriverDelegate
 private struct DefaultSessionsDriverDelegate: RedisSessionsDelegate {
-    func redis<Client>(_ client: Client, storeData data: SessionData, forID id: SessionID) -> EventLoopFuture<Void> where Client : RedisClient {
-        return client.set("\(id.string)", toJSON: data)
+    @inlinable
+    func redis<Client: RedisClient>(_ client: Client, store data: SessionData, with key: RedisKey) -> EventLoopFuture<Void> {
+        return client.set(key, toJSON: data)
     }
-    
-    func redis<Client>(_ client: Client, fetchDataForID id: SessionID) -> EventLoopFuture<SessionData?> where Client : RedisClient {
-        return client.get("\(id.string)", asJSON: SessionData.self)
+
+    @inlinable
+    func redis<Client: RedisClient>(_ client: Client, fetchDataFor key: RedisKey) -> EventLoopFuture<SessionData?> {
+        return client.get(key, asJSON: SessionData.self)
     }
 }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -107,7 +107,7 @@ class RedisTests: XCTestCase {
             sessionID = res.headers.setCookie?["vapor-session"]?.string
             XCTAssertEqual(res.status, .ok)
         }
-        XCTAssertNotNil(sessionID)
+        XCTAssertFalse(try XCTUnwrap(sessionID).contains("vrs-"), "session token has the redis key prefix!")
 
         try app.test(.GET, "/get", beforeRequest: { req in
             var cookies = HTTPCookies()


### PR DESCRIPTION
This addresses some semantic issues with the original implementation of `SessionDriver` for Redis in #175.

Two important changes were made to `RedisSessionsDelegate`:

1. `makeNewID` does not prefix the ID with `vrs-` anymore
1. A new `makeKey(for:)` optional method has been added to the protocol to convert an ID to a `RediStack.RedisKey` to customize how the id is represented as a key.
    - The default implementation adds the `vrs-` prefix.

In addition, the protocol has seen two quality of life (breaking) changes to the required protocol methods:

1. Their argument labels have been updated to read a bit nicer at call sites, and the `RedisKey` is now passed instead of a `SessionID`
    - `redis(_:storeData:forID:)` -> `redis(_:store:with:)`
    - `redis(_:fetchDataForID:)` -> `redis(_:fetchDataFor:)`
1. They have been marked `@inlinable` in the protocol definition. To take advantage of potential inlining, make sure you also mark your conformances with `@inlinable`.