### PR TITLE
Add cache protocol

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://gitlab.com/mordil/RediStack.git", from: "1.1.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", .branch("cache-protocol")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://gitlab.com/mordil/RediStack.git", from: "1.1.0"),
-        .package(url: "https://github.com/vapor/vapor.git", .branch("cache-protocol")),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.39.0"),
     ],
     targets: [
         .target(

--- a/Sources/Redis/Redis+Cache.swift
+++ b/Sources/Redis/Redis+Cache.swift
@@ -1,0 +1,45 @@
+import Vapor
+
+extension Application.Caches {
+    public var redis: Cache {
+        RedisCache(client: self.application.redis)
+    }
+}
+
+extension Application.Caches.Provider {
+    public static var redis: Self {
+        .init {
+            $0.caches.use { $0.caches.redis }
+        }
+    }
+}
+
+private struct RedisCache: Cache {
+    let client: RedisClient
+    
+    init(client: RedisClient) {
+        self.client = client
+    }
+    
+    func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
+        where T: Decodable
+    {
+        self.client.get(RedisKey(key), asJSON: T.self)
+    }
+    
+    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
+        where T: Encodable
+    
+    {
+        if let value = value {
+            return self.client.set(RedisKey(key), toJSON: value)
+        } else {
+            return self.client.delete(RedisKey(key))
+                .transform(to: ())
+        }
+    }
+    
+    func `for`(_ request: Request) -> Self {
+        .init(client: request.redis)
+    }
+}

--- a/Sources/Redis/Redis+Cache.swift
+++ b/Sources/Redis/Redis+Cache.swift
@@ -2,14 +2,22 @@ import Vapor
 
 extension Application.Caches {
     public var redis: Cache {
-        RedisCache(client: self.application.redis)
+        self.redis(.default)
+    }
+  
+    public func redis(_ id: RedisID) -> Cache {
+        RedisCache(client: self.application.redis(id))
     }
 }
 
 extension Application.Caches.Provider {
     public static var redis: Self {
+        self.redis(.default)
+    }
+
+    public static func redis(_ id: RedisID) -> Self {
         .init {
-            $0.caches.use { $0.caches.redis }
+            $0.caches.use { $0.caches.redis(id) }
         }
     }
 }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -123,11 +123,11 @@ class RedisTests: XCTestCase {
         let app = Application()
         defer { app.shutdown() }
         
-        app.caches.use(.redis)
         app.redis.configuration = try .init(
             hostname: env("REDIS_HOSTNAME") ?? "localhost",
             port: 6379
         )
+        app.caches.use(.redis)
 
         try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
         try app.cache.set("foo", to: "bar").wait()

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -119,6 +119,21 @@ class RedisTests: XCTestCase {
         }
     }
     
+    func testCache() throws {
+        let app = Application()
+        defer { app.shutdown() }
+        
+        app.caches.use(.redis)
+        app.redis.configuration = try .init(
+            hostname: env("REDIS_HOSTNAME") ?? "localhost",
+            port: 6379
+        )
+
+        try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
+        try app.cache.set("foo", to: "bar").wait()
+        try XCTAssertEqual(app.cache.get("foo", as: String.self).wait(), "bar")
+    }
+    
     override class func setUp() {
         XCTAssert(isLoggingConfigured)
     }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -127,6 +127,7 @@ class RedisTests: XCTestCase {
         
         app.redis.configuration = redisConfig
         app.caches.use(.redis)
+        try app.boot()
 
         try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
         try app.cache.set("foo", to: "bar").wait()

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -125,10 +125,7 @@ class RedisTests: XCTestCase {
         let app = Application()
         defer { app.shutdown() }
         
-        app.redis.configuration = try .init(
-            hostname: env("REDIS_HOSTNAME") ?? "localhost",
-            port: 6379
-        )
+        app.redis.configuration = redisConfig
         app.caches.use(.redis)
 
         try XCTAssertNil(app.cache.get("foo", as: String.self).wait())


### PR DESCRIPTION
Add Redis implementation for Vapor's new cache protocol: https://github.com/vapor/vapor/pull/2558

```swift
// Use redis as application cache
app.caches.use(.redis)
```