### PR TITLE
Use passed-in eventloop when acquiring RedisConnectionPool

### DIFF
--- a/Sources/Redis/Application+Redis.swift
+++ b/Sources/Redis/Application+Redis.swift
@@ -3,7 +3,7 @@ import Vapor
 extension Application {
     public struct Redis {
         func pool(for eventLoop: EventLoop) -> RedisConnectionPool {
-            self.application.redisStorage.pool(for: self.eventLoop.next(), id: self.id)
+            self.application.redisStorage.pool(for: eventLoop, id: self.id)
         }
 
         public let id: RedisID


### PR DESCRIPTION
Use the passed-in eventloop when acquiring RedisConnectionPool to prevent triggering a precondition related to ending up in a wrong eventloop (fixes #180, replaces: #183).