### PR TITLE
Add support for Vapor `Cache` protocol expiration time

### DIFF
--- a/Sources/Redis/RedisClient+Codable.swift
+++ b/Sources/Redis/RedisClient+Codable.swift
@@ -3,16 +3,31 @@ import Foundation
 
 extension RedisClient {
     /// Gets the provided key as a decodable type.
-    public func get<D>(_ key: RedisKey, asJSON type: D.Type) -> EventLoopFuture<D?> where D: Decodable {
+    public func get<D>(_ key: RedisKey, asJSON type: D.Type) -> EventLoopFuture<D?>
+        where D: Decodable
+    {
         return self.get(key, as: Data.self).flatMapThrowing { data in
             return try data.flatMap { try JSONDecoder().decode(D.self, from: $0) }
         }
     }
 
     /// Sets key to an encodable item.
-    public func set<E>(_ key: RedisKey, toJSON entity: E) -> EventLoopFuture<Void> where E: Encodable {
+    public func set<E>(_ key: RedisKey, toJSON entity: E) -> EventLoopFuture<Void>
+        where E: Encodable
+    {
         do {
             return try self.set(key, to: JSONEncoder().encode(entity))
+        } catch {
+            return self.eventLoop.makeFailedFuture(error)
+        }
+    }
+    
+    /// Sets key to an encodable item with an expiration time.
+    public func setex<E>(_ key: RedisKey, toJSON entity: E, expirationInSeconds expiration: Int) -> EventLoopFuture<Void>
+        where E: Encodable
+    {
+        do {
+            return try self.setex(key, to: JSONEncoder().encode(entity), expirationInSeconds: expiration)
         } catch {
             return self.eventLoop.makeFailedFuture(error)
         }

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -132,6 +132,12 @@ class RedisTests: XCTestCase {
         try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
         try app.cache.set("foo", to: "bar").wait()
         try XCTAssertEqual(app.cache.get("foo", as: String.self).wait(), "bar")
+        
+        // Test expiration
+        try app.cache.set("foo2", to: "bar2", expiresIn: .seconds(1)).wait()
+        try XCTAssertEqual(app.cache.get("foo2", as: String.self).wait(), "bar2")
+        sleep(1)
+        try XCTAssertNil(app.cache.get("foo2", as: String.self).wait())
     }
     
     override class func setUp() {


### PR DESCRIPTION
Adds support for setting an expiration time when using Redis as the Vapor cache via `app.caches.use(.redis)`. See [v4.44.0](https://github.com/vapor/vapor/releases/tag/4.44.0) for more info.

This PR also fixes #187 by adding a function to set an expiration time when setting a key to JSON:
```swift
app.redis.setex("user", toJSON: User(name: "mads"), expirationInSeconds: 10)
```
