### PR TITLE
Add support for TLS-backed connections to Redis

### DIFF
--- a/Sources/Redis/RedisStorage.swift
+++ b/Sources/Redis/RedisStorage.swift
@@ -1,5 +1,8 @@
 import Vapor
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
+import NIOSSL
 
 extension Application {
     private struct RedisStorageKey: StorageKey {
@@ -75,8 +78,26 @@ extension RedisStorage {
 
                     let newKey: PoolKey = PoolKey(eventLoopKey: eventLoop.key, redisID: redisID)
 
+                    let redisTLSClient: ClientBootstrap? = {
+                        guard let tlsConfig = configuration.tlsConfiguration, let tlsHost = configuration.tlsHostname else { return nil }
+
+                        return ClientBootstrap(group: eventLoop)
+                            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                            .channelInitializer { channel in
+                                do {
+                                    let sslContext = try NIOSSLContext(configuration: tlsConfig)
+                                    return EventLoopFuture.andAllSucceed([
+                                        channel.pipeline.addHandler(try NIOSSLClientHandler(context: sslContext, serverHostname: tlsHost)),
+                                        channel.pipeline.addBaseRedisHandlers()
+                                    ], on: channel.eventLoop)
+                                } catch {
+                                    return channel.eventLoop.makeFailedFuture(error)
+                                }
+                            }
+                    }()
+
                     let newPool = RedisConnectionPool(
-                        configuration: .init(configuration, defaultLogger: application.logger),
+                        configuration: .init(configuration, defaultLogger: application.logger, customClient: redisTLSClient),
                         boundEventLoop: eventLoop)
 
                     newPools[newKey] = newPool

--- a/Sources/Redis/RedisStorage.swift
+++ b/Sources/Redis/RedisStorage.swift
@@ -79,7 +79,8 @@ extension RedisStorage {
                     let newKey: PoolKey = PoolKey(eventLoopKey: eventLoop.key, redisID: redisID)
 
                     let redisTLSClient: ClientBootstrap? = {
-                        guard let tlsConfig = configuration.tlsConfiguration, let tlsHost = configuration.tlsHostname else { return nil }
+                        guard let tlsConfig = configuration.tlsConfiguration,
+                                let tlsHost = configuration.tlsHostname else { return nil }
 
                         return ClientBootstrap(group: eventLoop)
                             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -87,7 +88,8 @@ extension RedisStorage {
                                 do {
                                     let sslContext = try NIOSSLContext(configuration: tlsConfig)
                                     return EventLoopFuture.andAllSucceed([
-                                        channel.pipeline.addHandler(try NIOSSLClientHandler(context: sslContext, serverHostname: tlsHost)),
+                                        channel.pipeline.addHandler(try NIOSSLClientHandler(context: sslContext,
+                                                                                            serverHostname: tlsHost)),
                                         channel.pipeline.addBaseRedisHandlers()
                                     ], on: channel.eventLoop)
                                 } catch {


### PR DESCRIPTION
This PR adds TLS support to the current stable release of `vapor/redis` (and the underlying RediStack 1.x). There are three behaviour changes (all additive):

- The `RedisConfiguration` struct now has optional `tlsConfiguration` and `tlsHostname` properties.

- The `RedisConfiguration` struct constructors that take URLs now handle `rediss` URLs and will fill out the `tlsConfiguration` and `tlsHostname` properties with default values from the URL.

- If the `tlsConfiguration` and `tlsHostname` properties are set, a custom `ClientBootstrap` will be created when it's time to create a `RedisConnectionPool`, adding a `NIOSSLClientHandler` to the pipeline on top of the ones created by `addBaseRedisHandlers()`. If the properties _aren't_ set, the behaviour is as before. 

This PR allows `vapor/redis` to be used with hosting services like Heroku, which (in certain configurations) _require_ that you connect to Redis using TLS.

### Ramifications on Future Versions

The logic for this PR was "borrowed" from this PR on RediStack: https://gitlab.com/swift-server-community/RediStack/-/merge_requests/160

I'm aware that work is being done in RediStack to add this "properly". However, I need to use TLS now and I'd like to stay on stable releases as much as possible. I'm aware there's already work on the main branch here for RediStack 2.x. This PR is branched from the 4.8.0 release — hopefully it can be merged into a new 4.x release to tide us over until 5.x comes along.

### Example Usage

Here's how I'm using this addition in my Vapor app running on Heroku. Heroku self-signs its TLS certificates, so I need to turn off certificate verification:

```swift
guard let redisUrl = Environment.get("REDIS_TLS_URL") else { throw Abort(.expectationFailed) }

let poolOptions = RedisConfiguration.PoolOptions(minimumConnectionCount: 1, connectionRetryTimeout: .seconds(10))

var tlsConfig: TLSConfiguration = .makeClientConfiguration()
tlsConfig.certificateVerification = .none

var redisConfig = try RedisConfiguration(url: redisUrl, pool: poolOptions)
redisConfig.tlsConfiguration = tlsConfig
app.redis.configuration = redisConfig
```
