### PR TITLE
API Docs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,18 +1,14 @@
 name: deploy-api-docs
 on:
-   push:
-     branches:
-       - main
+  push:
+    branches:
+      - main
 
 jobs:
-  deploy:
-    name: api.vapor.codes
-    runs-on: ubuntu-latest
-    steps:
-    - name: Deploy api-docs
-      uses: appleboy/ssh-action@master
-      with:
-        host: vapor.codes
-        username: vapor
-        key: ${{ secrets.VAPOR_CODES_SSH_KEY }}
-        script: ./github-actions/deploy-api-docs.sh
+  build-and-deploy:
+     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@main
+     secrets: inherit
+     with:
+       package_name: redis
+       modules: Redis
+       pathsToInvalidate: /redis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,5 @@ jobs:
           uses: actions/checkout@v3
           with:
             fetch-depth: 0
-        - name: Remove exports
-          run: |
-            rm -rf Sources/Redis/Exports.swift
         - name: Build
-          run: swift build
+          run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,17 @@ jobs:
       - name: Run 'MultipleRedisTests' tests with Thread Sanitizer
         timeout-minutes: 20
         run: swift test --enable-test-discovery --sanitize=thread --filter MultipleRedisTests
+
+  test-exports:
+      name: Test exports
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out Vapor
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: Remove exports
+          run: |
+            rm -rf Sources/Redis/Exports.swift
+        - name: Build
+          run: swift build

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,5 @@
 version: 1
 metadata:
-  authors: “Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community.”
+  authors: "Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community."
+external_links:
+  documentation: "https://docs.vapor.codes/redis/overview/"

--- a/Sources/Redis/Application+Redis.swift
+++ b/Sources/Redis/Application+Redis.swift
@@ -1,4 +1,5 @@
 import Vapor
+import RediStack
 
 extension Application {
     public struct Redis {

--- a/Sources/Redis/Application.Redis+PubSub.swift
+++ b/Sources/Redis/Application.Redis+PubSub.swift
@@ -1,4 +1,5 @@
 import Vapor
+import RediStack
 
 extension Application.Redis {
     private struct PubSubKey: StorageKey, LockKey {

--- a/Sources/Redis/Docs.docc/index.md
+++ b/Sources/Redis/Docs.docc/index.md
@@ -1,0 +1,7 @@
+# ``Redis``
+
+Redis is a library to integrate [RediStack](https://github.com/Mordil/RediStack) with Vapor. It provides a number of extensions to both make configuring a Vapor application with Redis simple and to provide Redis implementations for Vapor protocols, such as the cache.
+
+## Overview
+
+For more details, check out the [docs](https://docs.vapor.codes/redis/overview/).

--- a/Sources/Redis/Docs.docc/index.md
+++ b/Sources/Redis/Docs.docc/index.md
@@ -1,6 +1,6 @@
 # ``Redis``
 
-Redis is a library to integrate [RediStack](https://github.com/Mordil/RediStack) with Vapor. It provides a number of extensions to both make configuring a Vapor application with Redis simple and to provide Redis implementations for Vapor protocols, such as the cache.
+Redis is a library to integrate [RediStack](https://gitlab.com/swift-server-community/RediStack) with Vapor. It provides a number of extensions to both make configuring a Vapor application with Redis simple and to provide Redis implementations for Vapor protocols, such as the cache.
 
 ## Overview
 

--- a/Sources/Redis/Exports.swift
+++ b/Sources/Redis/Exports.swift
@@ -1,1 +1,5 @@
+#if !BUILDING_DOCC
+
 //@_exported import RediStack
+
+#endif

--- a/Sources/Redis/Exports.swift
+++ b/Sources/Redis/Exports.swift
@@ -1,5 +1,8 @@
 #if !BUILDING_DOCC
 
-//@_exported import RediStack
+@_exported import RediStack
+@_exported import struct Foundation.URL
+@_exported import struct Logging.Logger
+@_exported import struct NIO.TimeAmount
 
 #endif

--- a/Sources/Redis/Exports.swift
+++ b/Sources/Redis/Exports.swift
@@ -1,1 +1,1 @@
-@_exported import RediStack
+//@_exported import RediStack

--- a/Sources/Redis/Redis+Cache.swift
+++ b/Sources/Redis/Redis+Cache.swift
@@ -1,5 +1,6 @@
 import Vapor
 import Foundation
+import RediStack
 
 // MARK: RedisCacheCoder
 

--- a/Sources/Redis/Redis+Concurrency.swift
+++ b/Sources/Redis/Redis+Concurrency.swift
@@ -1,6 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 import Vapor
+import RediStack
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Application.Redis {

--- a/Sources/Redis/Redis+Sessions.swift
+++ b/Sources/Redis/Redis+Sessions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Vapor
+import RediStack
 
 /// A delegate object that controls key behavior of an `Application.Redis.Sessions` driver.
 public protocol RedisSessionsDelegate {

--- a/Sources/Redis/RedisClient+Codable.swift
+++ b/Sources/Redis/RedisClient+Codable.swift
@@ -1,5 +1,6 @@
 import AsyncKit
 import Foundation
+import RediStack
 
 extension RedisClient {
     /// Gets the provided key as a decodable type.

--- a/Sources/Redis/RedisConfiguration.swift
+++ b/Sources/Redis/RedisConfiguration.swift
@@ -1,9 +1,8 @@
-@_exported import struct Foundation.URL
+import Foundation
 import NIOSSL
 import NIOPosix
-@_exported import struct Logging.Logger
-@_exported import struct NIO.TimeAmount
-import enum NIO.SocketAddress
+import Logging
+import NIOCore
 import RediStack
 
 /// Configuration for connecting to a Redis instance

--- a/Sources/Redis/RedisConfiguration.swift
+++ b/Sources/Redis/RedisConfiguration.swift
@@ -4,6 +4,7 @@ import NIOPosix
 @_exported import struct Logging.Logger
 @_exported import struct NIO.TimeAmount
 import enum NIO.SocketAddress
+import RediStack
 
 /// Configuration for connecting to a Redis instance
 public struct RedisConfiguration {

--- a/Sources/Redis/RedisStorage.swift
+++ b/Sources/Redis/RedisStorage.swift
@@ -3,6 +3,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 import NIOSSL
+import RediStack
 
 extension Application {
     private struct RedisStorageKey: StorageKey {

--- a/Sources/Redis/Request+Redis.swift
+++ b/Sources/Redis/Request+Redis.swift
@@ -1,4 +1,5 @@
 import Vapor
+import RediStack
 
 extension Request {
     public struct Redis {

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -2,6 +2,7 @@ import Redis
 import Vapor
 import Logging
 import XCTVapor
+import RediStack
 
 extension String {
     var int: Int? { Int(self) }


### PR DESCRIPTION
Updates for new API docs deployment methods.

Also removes a number of exports when building the docs so we don't build docs for all dependencies as well.
