### PR TITLE
Support Async Lifecycles

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,4 +11,4 @@ jobs:
      with:
        package_name: redis
        modules: Redis
-       pathsToInvalidate: /redis
+       pathsToInvalidate: /redis/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,36 @@ jobs:
   api-breakage:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
+    container: swift:jammy
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with: { 'fetch-depth': 0 }
-      - name: Run API breakage check action
-        uses: vapor/ci/.github/actions/ci-swift-check-api-breakage@reusable-workflows
+      - name: Run API breakage check
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          swift package diagnose-api-breaking-changes origin/main
+
+  gh-codeql:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    runs-on: ubuntu-latest
+    permissions: { actions: write, contents: read, security-events: write }
+    timeout-minutes: 30
+    steps:
+      - name: Install latest Swift toolchain
+        uses: vapor/swiftly-action@v0.1
+        with: { toolchain: latest }
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Fix Git configuration
+        run: 'git config --global --add safe.directory "${GITHUB_WORKSPACE}"'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with: { languages: swift }
+      - name: Perform build
+        run: swift build
+      - name: Run CodeQL analyze
+        uses: github/codeql-action/analyze@v3
 
   linux-unit:
     if: ${{ !(github.event.pull_request.draft || false) }}
@@ -47,22 +70,11 @@ jobs:
       redis-2:
         image: ${{ matrix.redis }}
     steps:
-      - name: Save Redis version to env
-        run: |
-          echo REDIS_VERSION='${{ matrix.redis }}' >> $GITHUB_ENV
-      - name: Display versions
-        shell: bash
-        run: |
-          if [[ '${{ contains(matrix.container, 'nightly') }}' == 'true' ]]; then
-            SWIFT_PLATFORM="$(source /etc/os-release && echo "${ID}${VERSION_ID}")" SWIFT_VERSION="$(cat /.swift_tag)"
-            printf 'SWIFT_PLATFORM=%s\nSWIFT_VERSION=%s\n' "${SWIFT_PLATFORM}" "${SWIFT_VERSION}" >>"${GITHUB_ENV}"
-          fi
-          printf 'OS:  %s\nTag: %s\nVersion:\n' "${SWIFT_PLATFORM}-${RUNNER_ARCH}" "${SWIFT_VERSION}" && swift --version
       - name: Check out package
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run unit tests with Thread Sanitizer and coverage
         run: swift test --sanitize=thread --enable-code-coverage
-      - name: Submit coverage report to Codecov.io
-        uses: vapor/swift-codecov-action@v0.2
+      - name: Upload coverage data
+        uses: vapor/swift-codecov-action@v0.3
         with:
-          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,REDIS_VERSION'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   api-breakage:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10
+    container: swift:5.10-jammy
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -33,9 +33,9 @@ jobs:
         container:
           - swift:5.8-focal
           - swift:5.9-jammy
-          - swift:5.10
-          - swiftlang/swift:nightly-6.0
-          - swiftlang/swift:nightly-main
+          - swift:5.10-jammy
+          - swiftlang/swift:nightly-6.0-jammy
+          - swiftlang/swift:nightly-main-jammy
         redis:
           - redis:6
           - redis:7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   api-breakage:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.8-jammy
+    container: swift:5.10
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -31,11 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - swift:5.6-focal
-          - swift:5.7-jammy
-          - swift:5.8-jammy
-          - swiftlang/swift:nightly-5.9-jammy
-          - swiftlang/swift:nightly-main-jammy
+          - swift:5.8-focal
+          - swift:5.9-jammy
+          - swift:5.10
+          - swiftlang/swift:nightly-6.0
+          - swiftlang/swift:nightly-main
         redis:
           - redis:6
           - redis:7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,26 +27,26 @@ jobs:
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           swift package diagnose-api-breaking-changes origin/main
 
-  gh-codeql:
-    if: ${{ !(github.event.pull_request.draft || false) }}
-    runs-on: ubuntu-latest
-    permissions: { actions: write, contents: read, security-events: write }
-    timeout-minutes: 30
-    steps:
-      - name: Install latest Swift toolchain
-        uses: vapor/swiftly-action@v0.1
-        with: { toolchain: latest }
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Fix Git configuration
-        run: 'git config --global --add safe.directory "${GITHUB_WORKSPACE}"'
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with: { languages: swift }
-      - name: Perform build
-        run: swift build
-      - name: Run CodeQL analyze
-        uses: github/codeql-action/analyze@v3
+  # gh-codeql:
+  #   if: ${{ !(github.event.pull_request.draft || false) }}
+  #   runs-on: ubuntu-latest
+  #   permissions: { actions: write, contents: read, security-events: write }
+  #   timeout-minutes: 30
+  #   steps:
+  #     - name: Install latest Swift toolchain
+  #       uses: vapor/swiftly-action@v0.1
+  #       with: { toolchain: latest }
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+  #     - name: Fix Git configuration
+  #       run: 'git config --global --add safe.directory "${GITHUB_WORKSPACE}"'
+  #     - name: Initialize CodeQL
+  #       uses: github/codeql-action/init@v3
+  #       with: { languages: swift }
+  #     - name: Perform build
+  #       run: swift build
+  #     - name: Run CodeQL analyze
+  #       uses: github/codeql-action/analyze@v3
 
   linux-unit:
     if: ${{ !(github.event.pull_request.draft || false) }}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -22,11 +22,16 @@ let package = Package(
             dependencies: [
                 .product(name: "RediStack", package: "RediStack"),
                 .product(name: "Vapor", package: "vapor"),
-            ]
+            ],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
         ),
-        .testTarget(name: "RedisTests", dependencies: [
-            .target(name: "Redis"),
-            .product(name: "XCTVapor", package: "vapor"),
-        ])
+        .testTarget(
+            name: "RedisTests",
+            dependencies: [
+                .target(name: "Redis"),
+                .product(name: "XCTVapor", package: "vapor"),
+            ],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+        )
     ]
 )

--- a/Sources/Redis/Application.Redis+PubSub.swift
+++ b/Sources/Redis/Application.Redis+PubSub.swift
@@ -3,7 +3,7 @@ import Vapor
 
 extension Application.Redis {
     private struct PubSubKey: StorageKey, LockKey {
-        typealias Value = [RedisID: RedisClient]
+        typealias Value = [RedisID: RedisClient & Sendable]
     }
 
     var pubsubClient: RedisClient {

--- a/Sources/Redis/Application.Redis+PubSub.swift
+++ b/Sources/Redis/Application.Redis+PubSub.swift
@@ -1,5 +1,5 @@
 import Vapor
-import RediStack
+@preconcurrency import RediStack
 
 extension Application.Redis {
     private struct PubSubKey: StorageKey, LockKey {

--- a/Sources/Redis/Redis+Cache.swift
+++ b/Sources/Redis/Redis+Cache.swift
@@ -1,20 +1,20 @@
 import Vapor
 import Foundation
-import RediStack
+@preconcurrency import RediStack
 import NIOCore
 
 // MARK: RedisCacheCoder
 
 /// An encoder whose output is convertible to a `RESPValue` for storage in Redis.
 /// Directly based on `Combine.TopLevelEncoder` but can't extend it because Combine isn't available on Linux.
-public protocol RedisCacheEncoder {
+public protocol RedisCacheEncoder: Sendable {
     associatedtype Output: RESPValueConvertible
     func encode<T>(_ value: T) throws -> Self.Output where T: Encodable
 }
 
 /// A decoder whose input is convertible from a `RESPValue` loaded from Redis.
 /// Directly based on `Combine.TopLevelDecoder` but can't extend it because Combine isn't available on Linux.
-public protocol RedisCacheDecoder {
+public protocol RedisCacheDecoder: Sendable {
     associatedtype Input: RESPValueConvertible
     func decode<T>(_ type: T.Type, from: Self.Input) throws -> T where T: Decodable
 }
@@ -66,7 +66,7 @@ extension Application.Caches.Provider {
 // MARK: - Redis cache driver
 
 /// `Cache` driver for storing cache data in Redis, using a provided encoder and decoder to serialize and deserialize values respectively.
-private struct RedisCache<CacheEncoder: RedisCacheEncoder, CacheDecoder: RedisCacheDecoder>: Cache {
+private struct RedisCache<CacheEncoder: RedisCacheEncoder, CacheDecoder: RedisCacheDecoder>: Cache, Sendable {
     let encoder: CacheEncoder
     let decoder: CacheDecoder
     let client: RedisClient

--- a/Sources/Redis/Redis+Sessions.swift
+++ b/Sources/Redis/Redis+Sessions.swift
@@ -4,7 +4,7 @@ import RediStack
 import NIOCore
 
 /// A delegate object that controls key behavior of an `Application.Redis.Sessions` driver.
-public protocol RedisSessionsDelegate {
+public protocol RedisSessionsDelegate: Sendable {
     /// Makes a new session ID token.
     /// - Note: This method is optional to implement.
     ///

--- a/Sources/Redis/RedisConfiguration.swift
+++ b/Sources/Redis/RedisConfiguration.swift
@@ -3,10 +3,10 @@ import NIOSSL
 import NIOPosix
 import Logging
 import NIOCore
-import RediStack
+@preconcurrency import RediStack
 
 /// Configuration for connecting to a Redis instance
-public struct RedisConfiguration {
+public struct RedisConfiguration: Sendable {
     public typealias ValidationError = RedisConnection.Configuration.ValidationError
 
     public var serverAddresses: [SocketAddress]
@@ -16,21 +16,22 @@ public struct RedisConfiguration {
     public var tlsConfiguration: TLSConfiguration?
     public var tlsHostname: String?
 
-    public struct PoolOptions {
+    public struct PoolOptions: Sendable {
         public var maximumConnectionCount: RedisConnectionPoolSize
         public var minimumConnectionCount: Int
         public var connectionBackoffFactor: Float32
         public var initialConnectionBackoffDelay: TimeAmount
         public var connectionRetryTimeout: TimeAmount?
-        public var onUnexpectedConnectionClose: ((RedisConnection) -> Void)?
+        public var onUnexpectedConnectionClose: (@Sendable (RedisConnection) -> Void)?
 
+        @preconcurrency
         public init(
             maximumConnectionCount: RedisConnectionPoolSize = .maximumActiveConnections(2),
             minimumConnectionCount: Int = 0,
             connectionBackoffFactor: Float32 = 2,
             initialConnectionBackoffDelay: TimeAmount = .milliseconds(100),
             connectionRetryTimeout: TimeAmount? = nil,
-            onUnexpectedConnectionClose: ((RedisConnection) -> Void)? = nil
+            onUnexpectedConnectionClose: (@Sendable (RedisConnection) -> Void)? = nil
         ) {
             self.maximumConnectionCount = maximumConnectionCount
             self.minimumConnectionCount = minimumConnectionCount

--- a/Sources/Redis/RedisID.swift
+++ b/Sources/Redis/RedisID.swift
@@ -16,7 +16,8 @@ public struct RedisID: Hashable,
                        ExpressibleByStringLiteral,
                        ExpressibleByStringInterpolation,
                        CustomStringConvertible,
-                       Comparable {
+                       Comparable,
+                       Sendable {
 
     public let rawValue: String
 

--- a/Sources/Redis/RedisStorage.swift
+++ b/Sources/Redis/RedisStorage.swift
@@ -3,7 +3,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 import NIOSSL
-import RediStack
+@preconcurrency import RediStack
 
 extension Application {
     private struct RedisStorageKey: StorageKey {
@@ -141,7 +141,7 @@ extension RedisStorage {
             }.flatten(on: application.eventLoopGroup.next())
 
             do {
-                try shutdownFuture.wait()
+                try await shutdownFuture.get()
             } catch {
                 application.logger.error("Error shutting down redis connection pools, possibly because the pool never connected to the Redis server: \(error)")
             }

--- a/Sources/Redis/RedisStorage.swift
+++ b/Sources/Redis/RedisStorage.swift
@@ -21,38 +21,38 @@ extension Application {
     }
 }
 
-final class RedisStorage {
-    private var lock: NIOLock
-    private var configurations: [RedisID: RedisConfiguration]
-    fileprivate var pools: [PoolKey: RedisConnectionPool] {
-        willSet {
-            guard pools.isEmpty else {
-                fatalError("Modifying connection pools after application has booted is not supported")
+final class RedisStorage: Sendable {
+    fileprivate struct StorageBox: Sendable {
+        var configurations: [RedisID: RedisConfiguration]
+        var pools: [PoolKey: RedisConnectionPool] {
+            willSet {
+                guard self.pools.isEmpty else {
+                    fatalError("Modifying connection pools after application has booted is not supported")
+                }
             }
         }
     }
+    private let box: NIOLockedValueBox<StorageBox>
 
     init() {
-        self.configurations = [:]
-        self.pools = [:]
-        self.lock = .init()
+        self.box = .init(.init(configurations: [:], pools: [:]))
     }
 
     func use(_ redisConfiguration: RedisConfiguration, as id: RedisID = .default) {
-        self.configurations[id] = redisConfiguration
+        self.box.withLockedValue { $0.configurations[id] = redisConfiguration }
     }
 
     func configuration(for id: RedisID = .default) -> RedisConfiguration? {
-        self.configurations[id]
+        self.box.withLockedValue { $0.configurations[id] }
     }
 
     func ids() -> Set<RedisID> {
-        Set(self.configurations.keys)
+        Set(self.box.withLockedValue { $0.configurations.keys })
     }
 
     func pool(for eventLoop: EventLoop, id redisID: RedisID) -> RedisConnectionPool {
         let key = PoolKey(eventLoopKey: eventLoop.key, redisID: redisID)
-        guard let pool = pools[key] else {
+        guard let pool = self.box.withLockedValue({ $0.pools[key] }) else {
             fatalError("No redis found for id \(redisID), or the app may not have finished booting. Also, the eventLoop must be from Application's EventLoopGroup.")
         }
         return pool
@@ -69,54 +69,48 @@ extension RedisStorage {
         }
 
         func didBoot(_ application: Application) throws {
-            self.redisStorage.lock.lock()
-            defer {
-                self.redisStorage.lock.unlock()
-            }
             var newPools: [PoolKey: RedisConnectionPool] = [:]
             for eventLoop in application.eventLoopGroup.makeIterator() {
-                for (redisID, configuration) in redisStorage.configurations {
+                redisStorage.box.withLockedValue { storageBox in
+                    for (redisID, configuration) in storageBox.configurations {
 
-                    let newKey: PoolKey = PoolKey(eventLoopKey: eventLoop.key, redisID: redisID)
+                        let newKey: PoolKey = PoolKey(eventLoopKey: eventLoop.key, redisID: redisID)
 
-                    let redisTLSClient: ClientBootstrap? = {
-                        guard let tlsConfig = configuration.tlsConfiguration,
-                                let tlsHost = configuration.tlsHostname else { return nil }
+                        let redisTLSClient: ClientBootstrap? = {
+                            guard let tlsConfig = configuration.tlsConfiguration,
+                                    let tlsHost = configuration.tlsHostname else { return nil }
 
-                        return ClientBootstrap(group: eventLoop)
-                            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-                            .channelInitializer { channel in
-                                do {
-                                    let sslContext = try NIOSSLContext(configuration: tlsConfig)
-                                    return EventLoopFuture.andAllSucceed([
-                                        channel.pipeline.addHandler(try NIOSSLClientHandler(context: sslContext,
-                                                                                            serverHostname: tlsHost)),
-                                        channel.pipeline.addBaseRedisHandlers()
-                                    ], on: channel.eventLoop)
-                                } catch {
-                                    return channel.eventLoop.makeFailedFuture(error)
+                            return ClientBootstrap(group: eventLoop)
+                                .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                                .channelInitializer { channel in
+                                    do {
+                                        let sslContext = try NIOSSLContext(configuration: tlsConfig)
+                                        return EventLoopFuture.andAllSucceed([
+                                            channel.pipeline.addHandler(try NIOSSLClientHandler(context: sslContext,
+                                                                                                serverHostname: tlsHost)),
+                                            channel.pipeline.addBaseRedisHandlers()
+                                        ], on: channel.eventLoop)
+                                    } catch {
+                                        return channel.eventLoop.makeFailedFuture(error)
+                                    }
                                 }
-                            }
-                    }()
+                        }()
 
-                    let newPool = RedisConnectionPool(
-                        configuration: .init(configuration, defaultLogger: application.logger, customClient: redisTLSClient),
-                        boundEventLoop: eventLoop)
+                        let newPool = RedisConnectionPool(
+                            configuration: .init(configuration, defaultLogger: application.logger, customClient: redisTLSClient),
+                            boundEventLoop: eventLoop)
 
-                    newPools[newKey] = newPool
+                        newPools[newKey] = newPool
+                    }
                 }
             }
 
-            self.redisStorage.pools = newPools
+            self.redisStorage.box.withLockedValue { $0.pools = newPools }
         }
 
         /// Close each connection pool
         func shutdown(_ application: Application) {
-            self.redisStorage.lock.lock()
-            defer {
-                self.redisStorage.lock.unlock()
-            }
-            let shutdownFuture: EventLoopFuture<Void> = redisStorage.pools.values.map { pool in
+            let shutdownFuture: EventLoopFuture<Void> = redisStorage.box.withLockedValue { $0.pools.values }.map { pool in
                 let promise = pool.eventLoop.makePromise(of: Void.self)
                 pool.close(promise: promise)
                 return promise.futureResult
@@ -130,11 +124,7 @@ extension RedisStorage {
         }
         
         func shutdownAsync(_ application: Application) async {
-            self.redisStorage.lock.lock()
-            defer {
-                self.redisStorage.lock.unlock()
-            }
-            let shutdownFuture: EventLoopFuture<Void> = redisStorage.pools.values.map { pool in
+            let shutdownFuture: EventLoopFuture<Void> = redisStorage.box.withLockedValue { $0.pools.values }.map { pool in
                 let promise = pool.eventLoop.makePromise(of: Void.self)
                 pool.close(promise: promise)
                 return promise.futureResult

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -2,7 +2,7 @@ import Redis
 import Vapor
 import Logging
 import XCTVapor
-import RediStack
+@preconcurrency import RediStack
 import XCTest
 
 extension String {


### PR DESCRIPTION
**These changes are now available in [4.11.0](https://github.com/vapor/redis/releases/tag/4.11.0)**


Support Vapor's async `LifecycleHandler` functions. This allows users to avoid calling `.wait()` when shutting down their Vapor apps, which can cause issues, for example, with trying to install a new concurrency executor.

This also updates the supported Swift version to 5.8