### PR TITLE
make Redis Sendable

### DIFF
--- a/Sources/Redis/Application+Redis.swift
+++ b/Sources/Redis/Application+Redis.swift
@@ -4,7 +4,7 @@ import NIOCore
 import Logging
 
 extension Application {
-    public struct Redis {
+    public struct Redis: Sendable {
         public let id: RedisID
 
         @usableFromInline


### PR DESCRIPTION
**These changes are now available in [4.11.1](https://github.com/vapor/redis/releases/tag/4.11.1)**


<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

- counter warning from `Application.Redis`: `Stored property 'redisInstances' of 'Sendable'-conforming class 'MyRedis' has non-sendable type '[Application.Redis]'; this is an error in the Swift 6 language mode`

example for more context:
```swift
extension Application {
    public final class MyRedis {
        struct MyRedisKey: StorageKey {
            typealias Value = Application.MyRedis
        }

        private let redisInstances: [Application.Redis]
    }
}
```

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
