### PR TITLE
add concurrency function for expire, exists, ttl, pttl

### DIFF
--- a/Sources/Redis/Redis+Concurrency.swift
+++ b/Sources/Redis/Redis+Concurrency.swift
@@ -54,30 +54,6 @@ extension Application.Redis {
     }
 }
 
-extension RedisClient {
-    /// Gets the provided key as a decodable type.
-    public func get<D>(_ key: RedisKey, asJSON type: D.Type, jsonDecoder: JSONDecoder = JSONDecoder()) async throws -> D?
-        where D: Decodable
-    {
-        let data = try await self.get(key, as: Data.self).get()
-        return try data.flatMap { try jsonDecoder.decode(D.self, from: $0) }
-    }
-
-    /// Sets key to an encodable item.
-    public func set<E>(_ key: RedisKey, toJSON entity: E, jsonEncoder: JSONEncoder = JSONEncoder()) async throws
-        where E: Encodable
-    {
-        try await self.set(key, to: jsonEncoder.encode(entity)).get()
-    }
-    
-    /// Sets key to an encodable item with an expiration time.
-    public func setex<E>(_ key: RedisKey, toJSON entity: E, expirationInSeconds expiration: Int, jsonEncoder: JSONEncoder = JSONEncoder()) async throws
-        where E: Encodable
-    {
-        try await self.setex(key, to: jsonEncoder.encode(entity), expirationInSeconds: expiration).get()
-    }
-}
-
 extension Request.Redis {
     public func send(command: String, with arguments: [RESPValue]) async throws -> RESPValue {
         try await self.request.application.redis(self.id)

--- a/Sources/Redis/RedisClient+Concurrency.swift
+++ b/Sources/Redis/RedisClient+Concurrency.swift
@@ -1,0 +1,74 @@
+import RediStack
+import Foundation
+
+extension RedisClient {
+    /// Gets the provided key as a decodable type.
+    public func get<D>(_ key: RedisKey, asJSON type: D.Type, jsonDecoder: JSONDecoder = JSONDecoder()) async throws -> D?
+    where D: Decodable
+    {
+        let data = try await self.get(key, as: Data.self).get()
+        return try data.flatMap { try jsonDecoder.decode(D.self, from: $0) }
+    }
+    
+    /// Sets key to an encodable item.
+    public func set<E>(_ key: RedisKey, toJSON entity: E, jsonEncoder: JSONEncoder = JSONEncoder()) async throws
+    where E: Encodable
+    {
+        try await self.set(key, to: jsonEncoder.encode(entity)).get()
+    }
+    
+    /// Sets key to an encodable item with an expiration time.
+    public func setex<E>(_ key: RedisKey, toJSON entity: E, expirationInSeconds expiration: Int, jsonEncoder: JSONEncoder = JSONEncoder()) async throws
+    where E: Encodable
+    {
+        try await self.setex(key, to: jsonEncoder.encode(entity), expirationInSeconds: expiration).get()
+    }
+    
+    /// Checks the existence of the provided keys in the database.
+    ///
+    /// [https://redis.io/commands/exists](https://redis.io/commands/exists)
+    /// - Parameter keys: A list of keys whose existence will be checked for in the database.
+    /// - Returns: The number of provided keys which exist in the database.
+    public func exists(_ keys: RedisKey...) async throws -> Int {
+        try await self.exists(keys).get()
+    }
+    
+    /// Checks the existence of the provided keys in the database.
+    ///
+    /// [https://redis.io/commands/exists](https://redis.io/commands/exists)
+    /// - Parameter keys: A list of keys whose existence will be checked for in the database.
+    /// - Returns: The number of provided keys which exist in the database.
+    public func exists(_ keys: [RedisKey]) async throws -> Int {
+        try await self.exists(keys).get()
+    }
+    
+    /// Sets a timeout on key. After the timeout has expired, the key will automatically be deleted.
+    /// - Note: A key with an associated timeout is often said to be "volatile" in Redis terminology.
+    ///
+    /// [https://redis.io/commands/expire](https://redis.io/commands/expire)
+    /// - Parameters:
+    ///     - key: The key to set the expiration on.
+    ///     - timeout: The time from now the key will expire at.
+    /// - Returns: `true` if the expiration was set.
+    public func expire(_ key: RedisKey, after timeout: TimeAmount) async throws -> Bool {
+        try await self.expire(key, after: timeout).get()
+    }
+    
+    /// Returns the remaining time-to-live (in seconds) of the provided key.
+    ///
+    /// [https://redis.io/commands/ttl](https://redis.io/commands/ttl)
+    /// - Parameter key: The key to check the time-to-live on.
+    /// - Returns: The number of seconds before the given key will expire.
+    public func ttl(_ key: RedisKey) async throws -> RedisKey.Lifetime {
+        try await self.ttl(key).get()
+    }
+    
+    /// Returns the remaining time-to-live (in milliseconds) of the provided key.
+    ///
+    /// [https://redis.io/commands/pttl](https://redis.io/commands/pttl)
+    /// - Parameter key: The key to check the time-to-live on.
+    /// - Returns: The number of milliseconds before the given key will expire.
+    public func pttl(_ key: RedisKey) async throws -> RedisKey.Lifetime {
+        try await self.pttl(key).get()
+    }
+}


### PR DESCRIPTION
**These changes are now available in [4.14.0](https://github.com/vapor/redis/releases/tag/4.14.0)**


add concurrency function for expire, exists, ttl, pttl

```swift
try await req.redis.expire(key1, after: .seconds(10)) == true 
try await req.redis.exists(key1, key2, key3) == 3
try await req.redis.exists([key1, key2, key3]) == 3
try await req.redis.ttl(key1) == RedisKey.Lifetime
try await req.redis.pttl(key1) == RedisKey.Lifetime
```